### PR TITLE
Removed parent from excluded field on service object

### DIFF
--- a/api/app/schemas/service_req_schema.py
+++ b/api/app/schemas/service_req_schema.py
@@ -29,6 +29,6 @@ class ServiceReqSchema(ma.ModelSchema):
     quantity = fields.Int()
     periods = fields.Nested(PeriodSchema, many=True, exclude=('accurate_time_ind', 'request_periods', 'reception_csr_ind', 'sr', 'state_periods',))
     sr_state = fields.Nested(SRStateSchema, exclude=('sr_state_desc',))
-    service = fields.Nested(ServiceSchema, exclude=('actual_service_ind', 'deleted', 'display_dashboard_ind', 'parent', 'prefix', 'service_code', 'service_desc',))
+    service = fields.Nested(ServiceSchema, exclude=('actual_service_ind', 'deleted', 'display_dashboard_ind', 'prefix', 'service_code', 'service_desc',))
     channel = fields.Nested(ChannelSchema)
     citizen = fields.Nested('CitizenSchema', exclude=('service_reqs',))


### PR DESCRIPTION
This causes the front end to break, as it was no longer able to
determine the category for a service when loading tables