### PR TITLE
Fixed bug which was causing the comparison for mostRecentActivePeriod…

### DIFF
--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -906,7 +906,7 @@ export const store = new Vuex.Store({
             let mostRecentActivePeriod = citizen.service_reqs[0].periods[0]
             citizen.service_reqs.forEach((request) => {
               request.periods.forEach((period) => {
-                if (period.end_time > mostRecentActivePeriod.end_time) {
+                if (period.time_end > mostRecentActivePeriod.time_end) {
                   mostRecentActivePeriod = period
                 }
               })


### PR DESCRIPTION
… to fail, and instead to find the CSR who first checked a citizen in, not the CSR who most reently dealt with a citizen