### PR TITLE
Performance tuning

### DIFF
--- a/api/app/patches/flask_oidc_patched.py
+++ b/api/app/patches/flask_oidc_patched.py
@@ -15,7 +15,7 @@ import logging
 
 class OpenIDConnect(OriginalOIDC):
 
-    @cache.memoize(timeout=60)
+    @cache.memoize(timeout=300)
     def _get_token_info(self, token):
         start_time = time.time()
         # We hardcode to use client_secret_post, because that's what the Google

--- a/api/app/resources/citizen/citizen_detail.py
+++ b/api/app/resources/citizen/citizen_detail.py
@@ -59,7 +59,7 @@ class CitizenDetail(Resource):
         db.session.add(citizen)
         db.session.commit()
 
-        socketio.emit('update_customer_list', {}, room=csr.office_id)
+        # socketio.emit('update_customer_list', {}, room=csr.office_id)
         result = self.citizen_schema.dump(citizen)
         socketio.emit('update_active_citizen', result.data, room=csr.office_id)
 

--- a/api/app/resources/citizen/citizen_finish_service.py
+++ b/api/app/resources/citizen/citizen_finish_service.py
@@ -45,7 +45,6 @@ class CitizenFinishService(Resource):
         db.session.add(citizen)
         db.session.commit()
 
-        socketio.emit('update_customer_list', {}, room=csr.office_id)
         socketio.emit('citizen_invited', {}, room='sb-%s' % csr.office.office_number)
         result = self.citizen_schema.dump(citizen)
         socketio.emit('update_active_citizen', result.data, room=csr.office_id)

--- a/api/app/resources/citizen/citizen_list.py
+++ b/api/app/resources/citizen/citizen_list.py
@@ -64,7 +64,7 @@ class CitizenList(Resource):
         db.session.add(citizen)
         db.session.commit()
 
-        socketio.emit('update_customer_list', {}, room=csr.office_id)
+        # socketio.emit('update_customer_list', {})
         result = self.citizen_schema.dump(citizen)
 
         return {'citizen': result.data,

--- a/api/app/resources/csrs.py
+++ b/api/app/resources/csrs.py
@@ -12,27 +12,38 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.'''
 
-from flask import request, g
+from flask import g
 from flask_restplus import Resource
 from qsystem import api, oidc
 from sqlalchemy import exc
-from app.models import CSR
-from app.schemas import CSRSchema
+from app.models import Citizen, CSR, Period, ServiceReq, SRState
+from app.schemas import CitizenSchema, CSRSchema
 
 
 @api.route("/csrs/me/", methods=["GET"])
 class Services(Resource):
 
     csr_schema = CSRSchema()
+    citizen_schema = CitizenSchema(many=True)
 
     @oidc.accept_token(require_token=True)
     def get(self):
         try:
-            print (g.oidc_token_info)
             csr = CSR.query.filter_by(username=g.oidc_token_info['username'].split("idir/")[-1]).first()
+            active_sr_state = SRState.query.filter_by(sr_code='Active').first()
+
+            active_citizens = Citizen.query \
+                .join(Citizen.service_reqs) \
+                .filter_by(sr_state_id=active_sr_state.sr_state_id) \
+                .join(ServiceReq.periods) \
+                .filter_by(csr_id=csr.csr_id) \
+                .filter(Period.time_end.is_(None))
+
             result = self.csr_schema.dump(csr)
+            active_citizens = self.citizen_schema.dump(active_citizens)
 
             return {'csr': result.data,
+                    'active_citizens': active_citizens.data,
                     'errors': result.errors}
 
         except exc.SQLAlchemyError as e:

--- a/api/app/resources/service_requests_detail.py
+++ b/api/app/resources/service_requests_detail.py
@@ -104,7 +104,7 @@ class ServiceRequestActivate(Resource):
         db.session.add(service_request)
         db.session.commit()
 
-        socketio.emit('update_customer_list', {}, room=csr.office_id)
+        # socketio.emit('update_customer_list', {})
         citizen_result = self.citizen_schema.dump(service_request.citizen)
         socketio.emit('update_active_citizen', citizen_result.data, room=csr.office_id)
         result = self.service_request_schema.dump(service_request)

--- a/api/app/resources/websocket.py
+++ b/api/app/resources/websocket.py
@@ -43,7 +43,7 @@ def on_join(message):
         if csr:
             join_room(csr.office_id)
             emit('joinRoomSuccess', {"sucess": True})
-            emit('update_customer_list', {"success": True}, room=csr.office_id)
+            emit('update_customer_list', {"success": True})
             print("Success")
         else:
             print("Fail")
@@ -62,7 +62,7 @@ def on_join_smartboard(message):
         print("Joining room: %s" % room)
 
         join_room(room)
-        emit('joinSmartboardRoomSuccess', {"success": True})
+        emit('joinSmartboardRoomSuccess')
     except KeyError as e:
         print(e)
         emit('joinSmartboardRoomFail', {"sucess": False, "message": "office_id must be passed to this method"})

--- a/frontend/src/Login.vue
+++ b/frontend/src/Login.vue
@@ -101,11 +101,6 @@ import { mapActions, mapGetters, mapMutations } from 'vuex'
       },
 
       setupKeycloakCallbacks(authenticated) {
-        this.$keycloak.onReady = (authenticated) => {
-          if (authenticated) {
-            this.$store.dispatch('logIn', this.$keycloak.token)
-          }
-        }
 
         this.$keycloak.onAuthSuccess = () => {
           this.$store.dispatch('logIn', this.$keycloak.token)

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -75,8 +75,7 @@ export const store = new Vuex.Store({
       },
       office_id: null,
       qt_xn_csr_ind: true,
-      receptionist_ind: null,
-      checkComplete: false
+      receptionist_ind: null
     },
   },
 
@@ -236,12 +235,6 @@ export const store = new Vuex.Store({
           return
         }
         context.commit('updateQueue', resp.data.citizens)
-        if (!context.state.checkComplete) {
-          context.dispatch('checkForUnfinishedService', resp.data.citizens).then(()=>{
-            context.commit('logCheckComplete', true)
-          })
-
-        }
       })
     },
 
@@ -301,6 +294,10 @@ export const store = new Vuex.Store({
           context.commit('setUser', resp.data.csr)
           let officeType = resp.data.csr.office.sb.sb_type
           context.commit('setOffice', officeType)
+
+          if (resp.data.active_citizens && resp.data.active_citizens.length > 0) {
+            context.dispatch('checkForUnfinishedService', resp.data.active_citizens)
+          }
           resolve(resp)
         }, error => {
           reject(error)
@@ -1130,8 +1127,6 @@ export const store = new Vuex.Store({
     flashServeNow: (state, payload) => state.serveNowStyle = payload,
 
     setServeNowAction: (state, payload) => state.serveNowAltAction = payload,
-
-    logCheckComplete: (state, payload) => state.checkComplete = payload,
 
     toggleFeedbackModal: (state, payload) => state.showFeedbackModal = payload,
 


### PR DESCRIPTION
Reduced the number of calls the frontend need to make to /citizens, since we can utilize the update_active_citizen websocket event
Increase the cached time for OIDC calls
Added active citizens to call to /me so we don't need to continually parse entire citizen list
Reduce the scope of some update_customer_list calls to be only the caller, instead of the entire office
Removed an unnecessary call to `logIn` from Login.vue