### PR TITLE
Create GA Board

### DIFF
--- a/api/app/models/__init__.py
+++ b/api/app/models/__init__.py
@@ -16,12 +16,12 @@ from .base import Base
 from .channel import Channel
 from .citizen import Citizen 
 from .citizen_state import CitizenState
+from .period_state import PeriodState
 from .csr import CSR
 from .csr_state import CSRState 
 from .metadata import MetaData
 from .office import Office
 from .period import Period
-from .period_state import PeriodState
 from .permission import Permission
 from .role import Role
 from .service import Service

--- a/api/app/models/csr.py
+++ b/api/app/models/csr.py
@@ -27,6 +27,9 @@ class CSR(Base):
     deleted = db.Column(db.DateTime, nullable=True)
     csr_state_id = db.Column(db.Integer, db.ForeignKey('csrstate.csr_state_id'), nullable=False)
 
+    periods = db.relationship("Period", primaryjoin="and_(CSR.csr_id==Period.csr_id,Period.time_end.is_(None))",
+                              lazy='joined', order_by='desc(Period.time_start)')
+
     def __repr__(self):
         return '<CSR Username:(name={self.username!r})>'.format(self=self)
 

--- a/api/app/schemas/__init__.py
+++ b/api/app/schemas/__init__.py
@@ -18,6 +18,7 @@ from .period_state_schema import PeriodStateSchema
 from .sr_state_schema import SRStateSchema
 from .channel_schema import ChannelSchema
 from .smartboard_schema import SmartBoardSchema
+from .role_schema import RoleSchema
 from .office_schema import OfficeSchema
 from .csr_schema import CSRSchema
 from .metadata_schema import MetaDataSchema
@@ -26,4 +27,3 @@ from .period_schema import PeriodSchema
 from .service_req_schema import ServiceReqSchema
 from .citizen_schema import CitizenSchema
 from .permission_schema import PermissionSchema
-from .role_schema import RoleSchema

--- a/api/app/schemas/csr_schema.py
+++ b/api/app/schemas/csr_schema.py
@@ -14,7 +14,7 @@ limitations under the License.'''
 
 from marshmallow import fields
 from app.models import CSR
-from app.schemas import OfficeSchema
+from app.schemas import CSRStateSchema, OfficeSchema, RoleSchema
 from qsystem import ma
 
 
@@ -31,4 +31,7 @@ class CSRSchema(ma.ModelSchema):
     receptionist_ind = fields.Int()
     deleted = fields.DateTime()
     csr_state_id = fields.Int()
+    csr_state = fields.Nested(CSRStateSchema, exclude=('csrs',))
     office = fields.Nested(OfficeSchema)
+    periods = fields.Nested('PeriodSchema', many=True, exclude=('csr',))
+    role = fields.Nested(RoleSchema, exclude=('roles',))

--- a/api/app/schemas/period_schema.py
+++ b/api/app/schemas/period_schema.py
@@ -32,4 +32,5 @@ class PeriodSchema(ma.ModelSchema):
     time_end = fields.DateTime()
     accurate_time_ind = fields.Integer()
     ps = fields.Nested(PeriodStateSchema, exclude=('ps_desc', 'ps_number',))
-    csr = fields.Nested(CSRSchema, exclude=('office',))
+    sr = fields.Nested("ServiceReqSchema", exclude=('periods',))
+    csr = fields.Nested(CSRSchema, exclude=('office', 'periods',))

--- a/frontend/src/Socket.vue
+++ b/frontend/src/Socket.vue
@@ -65,7 +65,6 @@ limitations under the License.*/
       },
 
       join() {
-        console.log(socket.connected)
         socket.emit('joinRoom',{count:0}, ()=>{console.log('socket emit: "joinRoom"')}
         )
       },

--- a/frontend/src/ga-screen/ga-screen.vue
+++ b/frontend/src/ga-screen/ga-screen.vue
@@ -1,0 +1,126 @@
+/*Copyright 2015 Province of British Columbia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.*/
+
+<template>
+  <div>
+    <div style="display: flex; flex-direction: row; justify-content: space-between">
+      <div></div>
+      <div v-if="reception">
+        <h5>Citizens Waiting</h5>
+        <h6>{{ this.ga_citizens_waiting() }}</h6>
+      </div>
+      <div v-if="!reception">
+        <h5>Citizens on Hold</h5>
+        <h6>{{ this.ga_citizens_on_hold() }}</h6>
+      </div>
+      <div>
+        <h5>Total CSRs</h5>
+        <h6>{{ this.ga_total_csrs() }}</h6>
+      </div>
+      <div>
+        <h5>Serving CSRs</h5>
+        <h6>{{ this.ga_serving_csrs() }}</h6>
+      </div>
+      <div></div>
+    </div>
+    <b-table small
+             head-variant="light"
+             :items="csrs"
+             :fields="fields"
+             outlined
+             class="p-0 m-0 w-100">
+    </b-table>
+  </div>
+</template>
+
+<script>
+
+import {
+  mapState, mapGetters, mapActions
+}
+from 'vuex'
+
+export default {
+  name: 'GAScreen',
+
+  mounted() {
+    this.timer = setInterval(() => {
+      this.refresh_board()
+    }, 10000)
+  },
+
+  beforeDestroy() {
+    clearInterval(this.timer);
+  },
+
+  data() {
+    return {
+      fields: [
+        {
+          key: 'username',
+          label: 'Staff Member',
+          sortable: true
+        },
+        {
+          key: 'periods[0].sr.service.service_name',
+          label: 'Service',
+          sortable: true
+        },
+        {
+          key: 'wait_time',
+          label: 'Wait Time',
+          sortable: true
+        },
+        {
+          key: 'serving_time',
+          label: 'Serving Time',
+          sortable: true,
+        },
+        {
+          key: 'periods[0].sr.citizen.citizen_comments',
+          label: 'Comments',
+          sortable: true,
+          formatter: (value) => { return value }
+        }
+      ],
+      timer: null
+    }
+  },
+  computed: {
+    ...mapState(['showGAScreenModal', 'csrs']),
+    ...mapGetters(['citizens_queue', 'on_hold_queue', 'reception'])
+  },
+  methods: {
+    ...mapActions(['closeGAScreenModal', 'getCsrs']),
+    ga_citizens_waiting() {
+      return this.citizens_queue.length
+    },
+    ga_citizens_on_hold() {
+      return this.on_hold_queue.length
+    },
+    ga_total_csrs() {
+      let allCsrs = this.csrs;
+      return allCsrs.length
+    },
+    ga_serving_csrs() {
+      let allCsrs = this.csrs.filter(c => c.periods.length > 0 && c.periods[0].ps.ps_name === "Being Served");
+      return allCsrs.length
+    },
+    refresh_board() {
+      this.getCsrs()
+    }
+  }
+}
+
+</script>

--- a/frontend/src/serve-citizen/dash-table.vue
+++ b/frontend/src/serve-citizen/dash-table.vue
@@ -100,7 +100,6 @@ limitations under the License.*/
       },
       showService(id) {
         let service = this.active_service_id(id)
-        console.log(service)
         if (!service) {
           return null
         }

--- a/frontend/src/serve-citizen/dash.vue
+++ b/frontend/src/serve-citizen/dash.vue
@@ -42,40 +42,51 @@ limitations under the License.*/
         </div>
         <div>
           <b-button class="btn-primary"
+                    style="margin-right: 20px"
+                    @click="clickGAScreen"
+                    v-if="user.role && user.role.role_code=='GA'">Toggle GA Panel</b-button>
+          <b-button class="btn-primary"
                     v-if="!showServiceModal"
                     @click="clickFeedback"
                     id="click-feedback-button">Feedback</b-button>
         </div>
       </div>
     </div>
-    <template v-if="reception && isLoggedIn">
-    <div v-bind:style="{width:'100%', height: `${qLengthH}px`}" class="font-900-rem">
-      Citizens Waiting: {{ queueLength }}
-    </div>
-
-  <div class="dash-table-holder" v-bind:style="{width:'100%', height:`${dashH}px`}">
-    <DashTable></DashTable>
-  </div>
-    <div v-bind:style="{width:'100%', height:`${qLengthH}px`}">
-      <div style="display: flex; width: 100%; justify-content: space-between;">
-        <div class="font-900-rem">Citizens on Hold: {{on_hold_queue.length}}</div>
-      <b-button variant="link" v-dragged="onDrag" class="m-0 p-0">
-        <font-awesome-icon icon="sort"
-                           class="m-0 p-0"
-                           style="font-size: 1.5rem;"></font-awesome-icon>
-      </b-button>
+    <div style="display: flex; flex-direction: row; justify-content: space-between;">
+      <div style="width: 100%">
+        <template v-if="reception && isLoggedIn">
+          <div v-bind:style="{width:'100%', height: `${qLengthH}px`}" class="font-900-rem">
+            Citizens Waiting: {{ queueLength }}
+          </div>
+          <div class="dash-table-holder" v-bind:style="{width:'100%', height:`${dashH}px`}">
+            <DashTable></DashTable>
+          </div>
+          <div v-bind:style="{width:'100%', height:`${qLengthH}px`}">
+            <div style="display: flex; width: 100%; justify-content: space-between;">
+              <div class="font-900-rem">Citizens on Hold: {{on_hold_queue.length}}</div>
+              <b-button variant="link" v-dragged="onDrag" class="m-0 p-0">
+                <font-awesome-icon icon="sort"
+                                   class="m-0 p-0"
+                                   style="font-size: 1.5rem;"></font-awesome-icon>
+              </b-button>
+            </div>
+          </div>
+          <div class="dash-table-holder" v-bind:style="{width:'100%',height:`${holdH}px`}">
+            <DashHoldTable></DashHoldTable>
+          </div>
+        </template>
+        <template v-else-if="!reception && isLoggedIn">
+          <div class="font-900-rem">Citizens on Hold: {{on_hold_queue.length}}</div>
+          <div class="dash-table-holder" v-bind:style="{width:'100%',height:`${fullHoldH}px`}">
+            <DashHoldTable></DashHoldTable>
+          </div>
+        </template>
+      </div>
+      <div v-if="showGAScreenModal"
+           style="margin-left: 1em; padding-top: 1em; width: 75%">
+        <GAScreen />
       </div>
     </div>
-    <div class="dash-table-holder" v-bind:style="{width:'100%',height:`${holdH}px`}">
-      <DashHoldTable></DashHoldTable>
-    </div>
-  </template>
-  <template v-else-if="!reception && isLoggedIn">
-    <div class="font-900-rem">Citizens on Hold: {{on_hold_queue.length}}</div>
-    <div class="dash-table-holder" v-bind:style="{width:'100%',height:`${fullHoldH}px`}">
-      <DashHoldTable></DashHoldTable>
-    </div>
-  </template>
   </div>
 </template>
 
@@ -84,6 +95,7 @@ import { mapState, mapGetters, mapActions, mapMutations } from 'vuex'
 import AddCitizen from './../add-citizen/add-citizen'
 import DashTable from './dash-table'
 import DashHoldTable from './dash-hold-table'
+import GAScreen from './../ga-screen/ga-screen'
 import ServeCitizen from './serve-citizen'
 
   export default {
@@ -93,6 +105,7 @@ import ServeCitizen from './serve-citizen'
       AddCitizen,
       DashTable,
       DashHoldTable,
+      GAScreen,
       ServeCitizen
     },
 
@@ -120,13 +133,14 @@ import ServeCitizen from './serve-citizen'
         checkedLocalStorage: false
       }
     },
-    
+
     computed: {
       ...mapGetters(['citizens_queue', 'on_hold_queue', 'reception']),
       ...mapState([
         'isLoggedIn',
         'citizenInvited',
         'dismissCountDown',
+        'showGAScreenModal',
         'showServiceModal',
         'serveNowStyle',
         'user'
@@ -153,7 +167,6 @@ import ServeCitizen from './serve-citizen'
     },
     watch: {
       csrId: function(val, oldVal) {
-        console.log(val)
         if (val) {
           this.checkLocalStorage(val)
         }
@@ -166,6 +179,7 @@ import ServeCitizen from './serve-citizen'
         'clickAddCitizen',
         'clickServiceModalClose',
         'clickCitizenLeft',
+        'clickGAScreen',
         'clickServeNow',
         'clickBackOffice'
       ]),
@@ -203,7 +217,6 @@ import ServeCitizen from './serve-citizen'
       checkLocalStorage(csrId) {
         this.checkedLocalStorage = true
         let offsetRatio = localStorage.getItem(`${csrId}offset`)
-        console.log(offsetRatio)
         if(offsetRatio) {
           this.isDragged = true
           let lastRatio = localStorage.getItem(`${csrId}last`)


### PR DESCRIPTION
Added GA Board as a panel on the main screen so GAs can view the board while serving / monitoring the queues.

*Table columns*
Staff member: username
Service: the service_name for the service_request they're serving, if any. Only tracks citizens in `Being Served` state
Wait time: (begin_service period start_time) - ticket_create_time
Serving time: now() - (begin_service period start_time)
Citizen comments: the comments for the citizen they are serving (if any). Only tracks citizens in `Being Served` state

*Aggregate Data*
Customers waiting: all customers in the "waiting" state (reception offices only)
Customers on hold: all customers in the "hold" state (non-reception offices only)
Total number of csrs: all csrs attached to that office
Serving csrs: CSRs who have an active service request that is in the "Being Served" state