### PR TITLE
Make the box part of checkbox controls more visible to CSRs

### DIFF
--- a/frontend/src/add-citizen/add-citizen.vue
+++ b/frontend/src/add-citizen/add-citizen.vue
@@ -32,11 +32,11 @@
         <AddCitizenForm />
         <b-container class="mt-3 pr-3">
           <b-row align-v="center" align-h="end">
-            <div v-if="reception">
-              <b-col cols="1" class="p-0 mr-1">Quick Txn?</b-col>
-              <b-col col cols="1" class="p-0">
-                <b-form-checkbox  v-model="quickTrans" value="1" unchecked-value="0"/>
-              </b-col>
+            <div v-if="reception" class="mr-1 btn-success" style="border-radius: 5px">
+              <b-form-checkbox v-model="quickTrans" value="1" unchecked-value="0"
+                               class="mt-1 ml-1 mr-1">
+                <span style="font: 400 16px Myriad-Pro;">Quick Txn</span>
+              </b-form-checkbox>
             </div>
             <Buttons />
           </b-row>

--- a/frontend/src/serve-citizen/serve-citizen.vue
+++ b/frontend/src/serve-citizen/serve-citizen.vue
@@ -98,11 +98,12 @@
                         :disabled="serviceBegun===false || performingAction"
                         class="w-100 btn-primary serve-btn"
                         id="serve-citizen-finish-button">Finish</b-button>
-              <div v-if="serviceBegun===true" class="px-3 pt-1" style="padding-right: 0 !important">
+              <div v-if="serviceBegun===true" class="px-3 pt-1 btn-warning"
+                   style="padding-right: 0 !important; border-radius: 5px; text-align: center">
                 <b-form-checkbox v-model="accurate_time_ind"
                                  value="0"
                                  unchecked-value="1">
-                  <span style="font-size: 1rem;">Inaccurate Time</span>
+                  <span  style="font: 400 16px Myriad-Pro;">Inaccurate Time</span>
                 </b-form-checkbox>
               </div>
             </b-col>


### PR DESCRIPTION
Put checkbox controls, Add and Serve citizen, in a background so check boxes are more visible.