### PR TITLE
Fix alert message so it displays correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,5 @@ docker-compose.yml
 api/init.sh
 api/wait-for-it.sh
 
+/frontend/static/keycloak-local.pathfinder-test.json
+/frontend/static/keycloak-local.pathfinder-dev.json

--- a/frontend/src/serve-citizen/dash.vue
+++ b/frontend/src/serve-citizen/dash.vue
@@ -14,7 +14,7 @@ limitations under the License.*/
 
 
 <template>
-  <div v-bind:style="{height: totalH}" class="dashmaincontainer" key="dashmaincontainer" v-if="user.username">
+  <div v-bind:style="{height: totalH, position: 'static'}" class="dashmaincontainer" key="dashmaincontainer" v-if="user.username">
     <div v-bind:style="{width:'100%', height:`${buttonH}px`}" v-if="isLoggedIn">
       <AddCitizen v-if="showAddModal"/>
       <ServeCitizen v-if="showServiceModal"/>


### PR DESCRIPTION
Now correctly pushes down the rest of the screen, so it can be read
- this was the same as previous behavior, which changed sometime in the past