### PR TITLE
Fix the color of the Serve Now button to flash orange

### DIFF
--- a/frontend/src/serve-citizen/dash-buttons.vue
+++ b/frontend/src/serve-citizen/dash-buttons.vue
@@ -102,4 +102,9 @@
     width: 100%;
     height: 100% !important;
   }
+  .btn-highlighted {
+    color: black;
+    border: 1px solid darkgoldenrod;
+    background-color: gold;
+  }
 </style>

--- a/frontend/src/serve-citizen/dash.vue
+++ b/frontend/src/serve-citizen/dash.vue
@@ -245,11 +245,6 @@ import ServeCitizen from './serve-citizen'
   .modal-main div {
     background-color: blue;
   }
-  .btn-highlighted {
-    color: black;
-    border: 1px solid darkgoldenrod;
-    background-color: gold;
-  }
   .loader {
     position: relative;
     text-align: center;


### PR DESCRIPTION
Moved definition of the .btn-highlighted class from dash.vue to dash-buttons.vue