### PR TITLE
Fix issue with Alembic migration history

### DIFF
--- a/api/migrations/versions/b0f5b7b6acf7_.py
+++ b/api/migrations/versions/b0f5b7b6acf7_.py
@@ -1,7 +1,7 @@
 """empty message
 
 Revision ID: b0f5b7b6acf7
-Revises: 2fc4029b8645
+Revises: cf50e7b9a32c
 Create Date: 2018-12-19 13:48:02.118918
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'b0f5b7b6acf7'
-down_revision = '2fc4029b8645'
+down_revision = 'cf50e7b9a32c'
 branch_labels = None
 depends_on = None
 

--- a/api/migrations/versions/eee726e68b4a_.py
+++ b/api/migrations/versions/eee726e68b4a_.py
@@ -1,7 +1,7 @@
 """empty message
 
 Revision ID: eee726e68b4a
-Revises: b0f5b7b6acf7
+Revises: 2fc4029b8645
 Create Date: 2018-12-19 10:36:17.211244
 
 """
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'eee726e68b4a'
-down_revision = 'b0f5b7b6acf7'
+down_revision = '2fc4029b8645'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
A revision was added in error further down the revision tree than upstream database revisions. This caused the upstream databases to not pick up a required change when deploying the app. This change correctly inserts the alembic migration file at the top of the chain, thus it should get deployed properly.