### PR TITLE
Update user cache

### DIFF
--- a/api/app/admin/csr.py
+++ b/api/app/admin/csr.py
@@ -116,7 +116,14 @@ class CSRConfig(Base):
 
         if self.validate_form(form) and self.update_model(form, model):
 
-            #  Clear cache for the user just edited
+            #  Trim the user name, if necessary.
+            updated_csr = CSR.query.filter_by(csr_id=csr_id).first()
+            if updated_csr.username != updated_csr.username.strip():
+                print("==> trimming user name")
+                updated_csr.username = updated_csr.username.strip()
+                db.session.add(updated_csr)
+                db.session.commit()
+
             socketio.emit('clear_csr_cache', { "id": csr_id})
 
             flash(gettext('''Record was successfully saved.'''), 'success')

--- a/api/app/admin/csr.py
+++ b/api/app/admin/csr.py
@@ -128,12 +128,12 @@ class CSRConfig(Base):
             print("==> Editor: " + current_user.username + "; Changing: " + updated_csr.username)
             print("    --> EId: " + str(current_user.csr_id) + "; RId: " + str(csr_id) + "; UId: " + str(updated_csr.csr_id))
 
-            # socketio.emit('clear_csr_cache', { "id": csr_id})
+            socketio.emit('clear_csr_cache', { "id": csr_id})
             socketio.emit('csr_update', \
                           {"csr_id": csr_id, \
                            "receptionist_ind": updated_csr.receptionist_ind}, \
                            room=current_user.office_id)
-            socketio.emit('clear_csr_cache', { "id": csr_id})
+            # socketio.emit('clear_csr_cache', { "id": csr_id})
 
             flash(gettext('''Record was successfully saved.'''), 'success')
             if '_add_another' in request.form:

--- a/api/app/admin/csr.py
+++ b/api/app/admin/csr.py
@@ -109,6 +109,9 @@ class CSRConfig(Base):
 
         #  We know model is good.  Save id of CSR you're editing for later use.
         csr_id = get_mdict_item_or_list(request.args, 'id')
+        #  Delete next two lines later.
+        csr_old = CSR.query.filter_by(csr_id=csr_id).first()
+        csr_office_old = csr_old.office.office_name
 
         form = self.edit_form(obj=model)
         if not hasattr(form, '_validated_ruleset') or not form._validated_ruleset:
@@ -125,8 +128,8 @@ class CSRConfig(Base):
                 db.session.commit()
 
             # auth_csr = CSR.find_by_username(g.oidc_token_info['username'])
-            print("==> Editor: " + current_user.username + "; Changing: " + updated_csr.username)
-            print("    --> EId: " + str(current_user.csr_id) + "; RId: " + str(csr_id) + "; UId: " + str(updated_csr.csr_id))
+            print("==> Edit: " + current_user.username + "; Ch: " + updated_csr.username + \
+                "; Old: " + csr_office_old + "; New: " + updated_csr.office.office_name)
 
             socketio.emit('clear_csr_cache', { "id": csr_id})
             socketio.emit('csr_update', \

--- a/api/app/admin/csr.py
+++ b/api/app/admin/csr.py
@@ -124,11 +124,16 @@ class CSRConfig(Base):
                 db.session.add(updated_csr)
                 db.session.commit()
 
-            socketio.emit('clear_csr_cache', { "id": csr_id})
+            # auth_csr = CSR.find_by_username(g.oidc_token_info['username'])
+            print("==> Editor: " + current_user.username + "; Changing: " + updated_csr.username)
+            print("    --> EId: " + str(current_user.csr_id) + "; RId: " + str(csr_id) + "; UId: " + str(updated_csr.csr_id))
+
+            # socketio.emit('clear_csr_cache', { "id": csr_id})
             socketio.emit('csr_update', \
                           {"csr_id": csr_id, \
                            "receptionist_ind": updated_csr.receptionist_ind}, \
-                          room=updated_csr.office_id)
+                           room=current_user.office_id)
+            socketio.emit('clear_csr_cache', { "id": csr_id})
 
             flash(gettext('''Record was successfully saved.'''), 'success')
             if '_add_another' in request.form:

--- a/api/app/admin/csr.py
+++ b/api/app/admin/csr.py
@@ -125,6 +125,10 @@ class CSRConfig(Base):
                 db.session.commit()
 
             socketio.emit('clear_csr_cache', { "id": csr_id})
+            socketio.emit('csr_update', \
+                          {"csr_id": csr_id, \
+                           "receptionist_ind": updated_csr.receptionist_ind}, \
+                          room=updated_csr.office_id)
 
             flash(gettext('''Record was successfully saved.'''), 'success')
             if '_add_another' in request.form:

--- a/api/app/admin/csr.py
+++ b/api/app/admin/csr.py
@@ -122,21 +122,15 @@ class CSRConfig(Base):
             #  Trim the user name, if necessary.
             updated_csr = CSR.query.filter_by(csr_id=csr_id).first()
             if updated_csr.username != updated_csr.username.strip():
-                print("==> trimming user name")
                 updated_csr.username = updated_csr.username.strip()
                 db.session.add(updated_csr)
                 db.session.commit()
-
-            # auth_csr = CSR.find_by_username(g.oidc_token_info['username'])
-            print("==> Edit: " + current_user.username + "; Ch: " + updated_csr.username + \
-                "; Old: " + csr_office_old + "; New: " + updated_csr.office.office_name)
 
             socketio.emit('clear_csr_cache', { "id": csr_id})
             socketio.emit('csr_update', \
                           {"csr_id": csr_id, \
                            "receptionist_ind": updated_csr.receptionist_ind}, \
                            room=current_user.office_id)
-            # socketio.emit('clear_csr_cache', { "id": csr_id})
 
             flash(gettext('''Record was successfully saved.'''), 'success')
             if '_add_another' in request.form:

--- a/api/app/models/theq/csr.py
+++ b/api/app/models/theq/csr.py
@@ -42,14 +42,15 @@ class CSR(Base):
 
     @classmethod
     def find_by_username(cls, username):
-        key = CSR.format_string % username
+        idir_id = username.split("idir/")[-1]
+        key = CSR.format_string % idir_id
         if cache.get(key):
             csr = cache.get(key)
             print("==> find_by_username: C: Yes, username: " + username + "; key: " + key + "; U: " + \
                   csr.username + "; O: " + csr.office.office_name)
             return cache.get(key)
 
-        csr = CSR.query.filter(CSR.deleted.is_(None)).filter_by(username=username.split("idir/")[-1]).first()
+        csr = CSR.query.filter(CSR.deleted.is_(None)).filter_by(username=idir_id).first()
         print("==> find_by_username: C: No, username: " + username + "; key: " + key + "; U: " + \
               csr.username + "; O: " + csr.office.office_name)
         cache.set(key, csr)
@@ -72,7 +73,8 @@ class CSR(Base):
 
     @classmethod
     def delete_user_cache(cls, username):
-        key = CSR.format_string % username
+        idir_id = username.split("idir/")[-1]
+        key = CSR.format_string % idir_id
         cache.delete(key)
 
     @classmethod

--- a/api/app/models/theq/csr.py
+++ b/api/app/models/theq/csr.py
@@ -43,7 +43,7 @@ class CSR(Base):
     @classmethod
     def find_by_username(cls, username):
         idir_id = username.split("idir/")[-1]
-        key = CSR.format_string % idir_id
+        key = (CSR.format_string % idir_id).lower()
         if cache.get(key):
             csr = cache.get(key)
             print("==> find_by_username: C: Yes, username: " + username + "; key: " + key + "; U: " + \
@@ -59,7 +59,7 @@ class CSR(Base):
     @classmethod
     def find_by_userid(cls, userid):
         csr = CSR.query.filter(CSR.deleted.is_(None)).filter_by(csr_id=userid).first()
-        key = CSR.format_string % csr.username
+        key = (CSR.format_string % csr.username).lower()
         if cache.get(key):
             csr = cache.get(key)
             print("==> find_by_userid: C: Yes, userid: " + userid + "; key: " + key + "; U: " + \
@@ -74,14 +74,14 @@ class CSR(Base):
     @classmethod
     def delete_user_cache(cls, username):
         idir_id = username.split("idir/")[-1]
-        key = CSR.format_string % idir_id
+        key = (CSR.format_string % idir_id).lower()
         cache.delete(key)
 
     @classmethod
     def update_user_cache(cls, userid):
         csr_cache_before = CSR.find_by_userid(userid)
         csr_db = CSR.query.filter_by(csr_id=userid).first()
-        key = CSR.format_string % csr_db.username
+        key = (CSR.format_string % csr_db.username).lower()
         cache.set(key, csr_db)
         csr_cache_after = CSR.find_by_userid(userid)
         print("==> update_user_cache: Key: " + key + "; CB: " + csr_cache_before.office.office_name + \

--- a/api/app/models/theq/csr.py
+++ b/api/app/models/theq/csr.py
@@ -67,9 +67,9 @@ class CSR(Base):
 
     @classmethod
     def update_user_cache(cls, userid):
-        print("==> Updating the user cache")
         csr = CSR.query.filter_by(csr_id=userid).first()
         key = CSR.format_string % csr.username
+        print("==> Updating the user cache, key: '" + key + "'")
         cache.set(key, csr)
 
     def get_id(self):

--- a/api/app/models/theq/csr.py
+++ b/api/app/models/theq/csr.py
@@ -45,14 +45,9 @@ class CSR(Base):
         idir_id = username.split("idir/")[-1]
         key = (CSR.format_string % idir_id).lower()
         if cache.get(key):
-            csr = cache.get(key)
-            print("==> find_by_username: C: Yes, username: " + username + "; key: " + key + "; U: " + \
-                  csr.username + "; O: " + csr.office.office_name)
             return cache.get(key)
 
         csr = CSR.query.filter(CSR.deleted.is_(None)).filter_by(username=idir_id).first()
-        print("==> find_by_username: C: No, username: " + username + "; key: " + key + "; U: " + \
-              csr.username + "; O: " + csr.office.office_name)
         cache.set(key, csr)
         return csr
 
@@ -61,13 +56,8 @@ class CSR(Base):
         csr = CSR.query.filter(CSR.deleted.is_(None)).filter_by(csr_id=userid).first()
         key = (CSR.format_string % csr.username).lower()
         if cache.get(key):
-            csr = cache.get(key)
-            print("==> find_by_userid: C: Yes, userid: " + userid + "; key: " + key + "; U: " + \
-                  csr.username + "; O: " + csr.office.office_name)
             return cache.get(key)
 
-        print("==> find_by_userid: C: No, userid: " + userid + "; key: " + key + "; U: " + \
-              csr.username + "; O: " + csr.office.office_name)
         cache.set(key, csr)
         return csr
 
@@ -79,14 +69,9 @@ class CSR(Base):
 
     @classmethod
     def update_user_cache(cls, userid):
-        csr_cache_before = CSR.find_by_userid(userid)
         csr_db = CSR.query.filter_by(csr_id=userid).first()
         key = (CSR.format_string % csr_db.username).lower()
         cache.set(key, csr_db)
-        csr_cache_after = CSR.find_by_userid(userid)
-        print("==> update_user_cache: Key: " + key + "; CB: " + csr_cache_before.office.office_name + \
-              "; DB: " + csr_db.office.office_name + "; CA: " + \
-              csr_cache_after.office.office_name)
 
     def get_id(self):
         return str(self.csr_id)

--- a/api/app/models/theq/csr.py
+++ b/api/app/models/theq/csr.py
@@ -67,10 +67,14 @@ class CSR(Base):
 
     @classmethod
     def update_user_cache(cls, userid):
-        csr = CSR.query.filter_by(csr_id=userid).first()
-        key = CSR.format_string % csr.username
-        print("==> Updating the user cache, key: '" + key + "'")
-        cache.set(key, csr)
+        csr_cache_before = CSR.find_by_userid(userid)
+        csr_db = CSR.query.filter_by(csr_id=userid).first()
+        key = CSR.format_string % csr_db.username
+        cache.set(key, csr_db)
+        csr_cache_after = CSR.find_by_userid(userid)
+        print("==> Key: " + key + "; CB: " + csr_cache_before.office.office_name + \
+              "; CA: " + csr_cache_after.office.office_name + "; DB: " + \
+              csr_db.office.office_name)
 
     def get_id(self):
         return str(self.csr_id)

--- a/api/app/models/theq/csr.py
+++ b/api/app/models/theq/csr.py
@@ -44,9 +44,14 @@ class CSR(Base):
     def find_by_username(cls, username):
         key = CSR.format_string % username
         if cache.get(key):
+            csr = cache.get(key)
+            print("==> find_by_username: C: Yes, username: " + username + "; key: " + key + "; U: " + \
+                  csr.username + "; O: " + csr.office.office_name)
             return cache.get(key)
 
         csr = CSR.query.filter(CSR.deleted.is_(None)).filter_by(username=username.split("idir/")[-1]).first()
+        print("==> find_by_username: C: No, username: " + username + "; key: " + key + "; U: " + \
+              csr.username + "; O: " + csr.office.office_name)
         cache.set(key, csr)
         return csr
 
@@ -55,8 +60,13 @@ class CSR(Base):
         csr = CSR.query.filter(CSR.deleted.is_(None)).filter_by(csr_id=userid).first()
         key = CSR.format_string % csr.username
         if cache.get(key):
+            csr = cache.get(key)
+            print("==> find_by_userid: C: Yes, userid: " + userid + "; key: " + key + "; U: " + \
+                  csr.username + "; O: " + csr.office.office_name)
             return cache.get(key)
 
+        print("==> find_by_userid: C: No, userid: " + userid + "; key: " + key + "; U: " + \
+              csr.username + "; O: " + csr.office.office_name)
         cache.set(key, csr)
         return csr
 
@@ -72,9 +82,9 @@ class CSR(Base):
         key = CSR.format_string % csr_db.username
         cache.set(key, csr_db)
         csr_cache_after = CSR.find_by_userid(userid)
-        print("==> Key: " + key + "; CB: " + csr_cache_before.office.office_name + \
-              "; CA: " + csr_cache_after.office.office_name + "; DB: " + \
-              csr_db.office.office_name)
+        print("==> update_user_cache: Key: " + key + "; CB: " + csr_cache_before.office.office_name + \
+              "; DB: " + csr_db.office.office_name + "; CA: " + \
+              csr_cache_after.office.office_name)
 
     def get_id(self):
         return str(self.csr_id)

--- a/api/app/resources/theq/csr_detail.py
+++ b/api/app/resources/theq/csr_detail.py
@@ -48,7 +48,6 @@ class Services(Resource):
         db.session.commit()
 
         result = self.csr_schema.dump(edit_csr)
-        print("==> emitting csr_update from Python")
         socketio.emit('csr_update', \
                       { "csr_id": edit_csr.csr_id, \
                         "receptionist_ind" : edit_csr.receptionist_ind }, \

--- a/api/app/resources/theq/csrs.py
+++ b/api/app/resources/theq/csrs.py
@@ -64,7 +64,6 @@ class CsrSelf(Resource):
             if not csr:
                 return {'Message': 'User Not Found'}, 404
 
-            print("==> CsrSelf: get(self): Csr: " + csr.username + "; Office: " + csr.office.office_name)
             db.session.add(csr)
             active_sr_state = SRState.get_state_by_name("Active")
             today = datetime.now()

--- a/api/app/resources/theq/csrs.py
+++ b/api/app/resources/theq/csrs.py
@@ -64,7 +64,7 @@ class CsrSelf(Resource):
             if not csr:
                 return {'Message': 'User Not Found'}, 404
 
-            print("==> CsrSelf(Resource), after find_by_username: Office: " + csr.office.office_name)
+            print("==> CsrSelf: get(self): Csr: " + csr.username + "; Office: " + csr.office.office_name)
             db.session.add(csr)
             active_sr_state = SRState.get_state_by_name("Active")
             today = datetime.now()

--- a/api/app/resources/theq/csrs.py
+++ b/api/app/resources/theq/csrs.py
@@ -64,6 +64,7 @@ class CsrSelf(Resource):
             if not csr:
                 return {'Message': 'User Not Found'}, 404
 
+            print("==> CsrSelf(Resource), after find_by_username: Office: " + csr.office.office_name)
             db.session.add(csr)
             active_sr_state = SRState.get_state_by_name("Active")
             today = datetime.now()

--- a/frontend/src/Socket.vue
+++ b/frontend/src/Socket.vue
@@ -74,9 +74,7 @@ limitations under the License.*/
       },
 
       onCSRUpdate(data){
-          console.log('==> socket received: "updateCSRList"')
-          console.log("    --> csr_id:           " + data.csr_id.toString())
-          console.log("    --> receptionist_ind: " + data.receptionist_ind.toString())
+          console.log('socket received: "csr_update"')
           this.$store.dispatch('getCsrs')
       },
 

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.0.17
+          v1.0.18
         </div>
       </div>
     </div>

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.0.18
+          v1.0.19
         </div>
       </div>
     </div>

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.0.16
+          v1.0.17
         </div>
       </div>
     </div>


### PR DESCRIPTION
Final fixes to update cache immediately when CSR changes office
- trim leading, trailing blanks on idir name
- trim any idir/ prefix on cache keys
- make all cache keys lower case
- add a call to emit csr_update, right after clear_csr_cache, to update users