### PR TITLE
Added Support For Appointment Lengths Other than 15

### DIFF
--- a/frontend/src/appointments/appointments.vue
+++ b/frontend/src/appointments/appointments.vue
@@ -1,6 +1,6 @@
 <template>
   <fragment>
-    <ApptBookingModal :clickedTime="clickedTime" :clickedAppt="clickedAppt"/>
+    <ApptBookingModal :clickedTime="clickedTime"  :clickedAppt="clickedAppt"/>
     <CheckInModal :clickedAppt="clickedAppt" />
     <keep-alive>
       <full-calendar ref="appointments"
@@ -44,8 +44,8 @@
       this.getAppointments()
       this.getServices()
       this.getChannels()
-      this.$root.$on('clearappt', () =>  { this.clearAppt() })
-      this.$root.$on('cleardate', () =>  { this.clearDate() })
+      this.$root.$on('clear-clicked-appt', () =>  { this.clearClickedAppt() })
+      this.$root.$on('clear-clicked-time', () =>  { this.clearClickedTime() })
       this.$root.$on('agendaDay', () => { this.agendaDay() })
       this.$root.$on('agendaWeek', () => { this.agendaWeek() })
       this.$root.$on('month', () => { this.month() })
@@ -60,6 +60,7 @@
         clickedAppt: null,
         clickedTime: null,
         config: {
+          selectOverlap: false,
           columnHeaderFormat: 'ddd/D',
           selectAllow: () => {
             return true
@@ -132,7 +133,7 @@
       events() {
         return null
       },
-      eventSelected(event, jsEvent, view) {
+      eventSelected(event) {
         this.clickedAppt = event
         this.highlightEvent(event)
         this.toggleCheckInModal(true)
@@ -158,7 +159,14 @@
       selectEvent(event) {
         this.unselect()
         let start = event.start.clone()
-        let end = event.start.clone().add(15, 'minutes')
+        let end
+        for (let l of [15, 30, 45, 60]) {
+          let testEnd = moment(start).clone().add(l, 'minutes')
+          if (this.appointment_events.find(event => moment(event.start).isBetween(start, testEnd))) {
+            break
+          }
+          end = testEnd
+        }
         let e = {
           start,
           end,
@@ -168,11 +176,11 @@
         this.setTempEvent(e)
         this.toggleApptBookingModal(true)
       },
-      clearAppt() {
+      clearClickedAppt() {
         this.clickedAppt = null
       },
-      clearDate() {
-        this.clickedDate = null
+      clearClickedTime() {
+        this.clickedTime = null
       },
       today() {
         this.$refs.appointments.fireMethod('today')
@@ -187,8 +195,8 @@
       },
       setTempEvent(event) {
         this.removeTempEvent()
-        let start = event.start.clone()
-        let end = event.end.clone()
+        let start = moment(event.start).clone()
+        let end = moment(event.end).clone()
         let e = {
           start,
           end,

--- a/frontend/src/appointments/checkin-modal.vue
+++ b/frontend/src/appointments/checkin-modal.vue
@@ -1,5 +1,6 @@
 <template>
   <b-modal v-model="modalVisible"
+           @shown="clearTime"
            modal-class="q-modal"
            body-class="q-modal"
            no-close-on-backdrop
@@ -55,6 +56,9 @@
         this.postCheckIn(this.clickedAppt).then( () => {
           this.hide()
         })
+      },
+      clearTime() {
+        this.$root.$emit('cleardate')
       },
       hide() {
         this.getAppointments().then( () => {

--- a/frontend/src/exams/edit-group-exam-modal.vue
+++ b/frontend/src/exams/edit-group-exam-modal.vue
@@ -2,7 +2,7 @@
   <b-modal v-model="modalVisible"
            :no-close-on-backdrop="true"
            hide-header
-           @shown="setValues"
+           @shown="show"
            hide-footer
            size="md">
     <div v-if="showModal">
@@ -423,14 +423,14 @@
           })
         })
       },
-      setValues() {
+      show() {
         let tempItem = Object.assign({}, this.actionedExam)
         if (tempItem.booking && tempItem.booking.start_time) {
           let { start_time } = tempItem.booking
           let { timezone_name } = this.actionedExam.booking.office.timezone
-          let time = zone.tz(start_time, timezone_name).clone().format('MMM-dd-YYYY HH:mm:ss').toString()
-          this.time = moment(time).format('ddd MMM DD YYYY HH:mm:ss [GMT]ZZ')
-          this.date = zone.tz(start_time, timezone_name).clone().format('ddd MMM DD YYYY HH:mm:ss [GMT]ZZ')
+          let time = zone.tz(start_time, timezone_name).clone().format('YYYY-MM-DD[T]HH:mm:ss').toString()
+          this.time = moment(time).format('YYYY-MM-DD[T]HH:mm:ssZ').toString()
+          this.date = zone.tz(start_time, timezone_name).clone().format('YYYY-MM-DD[T]HH:mm:ssZ').toString()
           if (tempItem.booking.sbc_staff_invigilated) {
             this.invigilator_id = 'sbc'
           } else {

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -108,6 +108,8 @@
     <div :style="tableStyle" class="my-0 mx-3">
       <b-table :items="filteredExams()"
                :fields="fields"
+               sort-by="exam_id"
+               :sort-desc="true"
                head-variant="light"
                :style="availableH"
                empty-text="There are no exams that match this filter criteria"
@@ -180,10 +182,16 @@
 
           <template v-if="stillRequires(row.item).length > 0">
             <div class="details-slot-div">
-              <div class="ml-3" style="font-size: 1rem;">Still Requires:</div>
+              <div class="ml-3" style="font-size: 1rem; flex-grow: 1;">Still Requires:</div>
               <template v-for="req in stillRequires(row.item)">
-                <div key="i+'it'" class="ml-3 mt-1">{{ req }}</div>
+                <div key="i+'it'" class="ml-3 mt-1" style="flex-grow: 1;">{{ req }}</div>
               </template>
+              <div style="flex-grow: 6" />
+              <div style="flex-grow: 1; font-size: 1rem;">Details</div>
+              <template v-for="(val, key) in readyDetailsMap(row.item)">
+                <div class="ml-3 mt-1" style="flex-grow: 1;"><b>{{ key }}: </b> {{ val }} </div>
+              </template>
+              <div style="flex-grow: 12" />
             </div>
           </template>
         </template>
@@ -354,28 +362,30 @@
       fields() {
         if (!this.showExamInventoryModal) {
           return [
-            { key: 'event_id', label: 'Event ID', sortable: true, thStyle: 'width: 6%' },
+            { key: 'exam_id', sortable: true, style: 'display: none', thClass: 'd-none', tdClass: 'd-none'},
+            { key: 'event_id', label: 'Event ID', sortable: false, thStyle: 'width: 6%' },
             { key: 'exam_type_name', label: 'Exam Type', sortable: true },
             { key: 'exam_name', label: 'Exam Name', sortable: true, thStyle: 'width: 11%' },
-            { key: 'exam_method', label: 'Method', sortable: true, thStyle: 'width: 5%' },
+            { key: 'exam_method', label: 'Method', sortable: false, thStyle: 'width: 5%' },
             { key: 'expiry_date', label: 'Expiry Date', sortable: true, thStyle: 'width: 8%' },
             { key: 'exam_received', label: 'Received?', sortable: true, thStyle: 'width: 5%' },
             { key: 'examinee_name', label: 'Student Name', sortable: true, thStyle: 'width: 12%' },
-            { key: 'notes', label: 'Notes', sortable: true, thStyle: 'width: 21%' },
-            { key: 'scheduled', label: 'Scheduled?', thStyle: 'width: 5%', tdClass: 'text-center'},
-            { key: 'actions', label: 'Actions', sortable: true, thStyle: 'width: 5%' },
+            { key: 'notes', label: 'Notes', sortable: false, thStyle: 'width: 21%' },
+            { key: 'scheduled', label: 'Scheduled?', sortable: false, thStyle: 'width: 5%', tdClass: 'text-center'},
+            { key: 'actions', label: 'Actions', sortable: false, thStyle: 'width: 5%' },
           ]
         }
         if (this.showExamInventoryModal) {
           return [
-            { key: 'event_id', label: 'Event ID', sortable: true, thStyle: 'width: 6%' },
+            { key: 'exam_id', sortable: true, thStyle: 'display: none'},
+            { key: 'event_id', label: 'Event ID', sortable: false, thStyle: 'width: 6%' },
             { key: 'exam_type.exam_type_name', label: 'Exam Type', sortable: true},
             { key: 'exam_name', label: 'Exam Name', sortable: true, thStyle: 'width: 15%' },
             { key: 'exam_method', label: 'Method', sortable: true, thStyle: 'width: 5%' },
             { key: 'expiry_date', label: 'Expiry Date', sortable: true, thStyle: 'width: 8%' },
             { key: 'exam_received', label: 'Received?', sortable: true, thStyle: 'width: 5%' },
             { key: 'examinee_name', label: 'Student Name', sortable: true, thStyle: 'width: 20%' },
-            { key: 'notes', label: 'Notes', sortable: true, },
+            { key: 'notes', label: 'Notes', sortable: false, },
           ]
         }
       },
@@ -638,6 +648,28 @@
         }
         if (item.booking && !item.booking.invigilator_id && !item.booking.sbc_staff_invigilated) {
           output.push('Assignment of Invigilator')
+        }
+        return output
+      },
+      readyDetailsMap(item) {
+        let output = {}
+        if (item.offsite_location && item.offsite_location !== '_offsite') {
+          output.Location = item.offsite_location
+        }
+        if (item.booking) {
+          if (item.booking.sbc_staff_invigilated) {
+            output.Invigilator = 'SBC Staff'
+          }
+          if (item.booking.invigilator_id) {
+            output.Invigilator = item.booking.invigilator.invigilator_name
+          }
+          if (item.booking.room_id) {
+            output.Room = item.booking.room.room_name
+          }
+          if (item.booking.start_time) {
+            output.Date = this.formatDate(item.booking.start_time)
+            output.Time = this.formatTime(item.booking)
+          }
         }
         return output
       },

--- a/frontend/src/store/appointments-module.js
+++ b/frontend/src/store/appointments-module.js
@@ -149,8 +149,6 @@ export default {
     },
     
     postServiceReq({rootState}, payload) {
-      console.log(payload.service_id)
-      console.log(payload.channel_id)
       let state = rootState
       let service_request = {
         service_id: payload.service_id,


### PR DESCRIPTION
Added logic to check amount of time availabe until next appointment and populate list of time lengths in  increments of 15 minutes up to 60 minutes or available time.  new appts always default to 15 mins.  If re-scheduling, avaialble time is calculated and previous booking length is used  for the default length.  If previous booking is longer than available time, defaults to available time.

Also...

-Fixed issue with Time display in EditGroupExamModal that was happening in Firefox
-Added display of Additional Details in details row in ExamInventoryTable when exam is 'not ready'
-Added hidden column of 'exam_id' to InventoryTable for default sorting (in descending order) so newest exams go on top