### PR TITLE
Sprint 11 2 (#259)

### DIFF
--- a/api/app/resources/theq/csrs.py
+++ b/api/app/resources/theq/csrs.py
@@ -89,7 +89,8 @@ class CsrSelf(Resource):
                 .join(ExamType, Exam.exam_type_id == ExamType.exam_type_id) \
                 .filter(ExamType.group_exam_ind == 1) \
                 .join(Booking, Exam.booking_id == Booking.booking_id) \
-                .filter(Booking.invigilator_id.is_(None)).count()
+                .filter(Booking.invigilator_id.is_(None))\
+                .filter(Booking.sbc_staff_invigilated == 0).count()
 
             result = self.csr_schema.dump(csr)
             active_citizens = self.citizen_schema.dump(active_citizens)

--- a/frontend/src/booking/scheduling-indicator.vue
+++ b/frontend/src/booking/scheduling-indicator.vue
@@ -74,7 +74,7 @@
           return
         }
         let pushToExams = false
-        if (this.selectedExam && this.selectedExam.referrer === 'scheduling') {
+        if (this.selectedExam && this.selectedExam.referrer === 'inventory') {
           pushToExams = true
         }
         this.finishBooking()

--- a/frontend/src/exams/add-exam-form-confirm.vue
+++ b/frontend/src/exams/add-exam-form-confirm.vue
@@ -75,10 +75,10 @@
         <span class="confirm-header">Received Date</span>
       </b-col>
       <b-col align-self="end" v-if="setup === 'individual'">
-        <span class="confirm-item">{{ exam.exam_received_date }}</span>
+        <span class="confirm-item">{{ formatDate(exam.exam_received_date) }}</span>
       </b-col>
       <b-col align-self="end" v-else>
-        <span v-if="!tab.showRadio" class="confirm-item">{{ exam.exam_received_date }}</span>
+        <span v-if="!tab.showRadio" class="confirm-item">{{ formatDate(exam.exam_received_date) }}</span>
         <span v-if="tab.showRadio" class="confirm-item">Not Yet Received</span>
       </b-col>
     </b-row>

--- a/frontend/src/exams/edit-exam-form-modal.vue
+++ b/frontend/src/exams/edit-exam-form-modal.vue
@@ -9,10 +9,13 @@
     <FailureExamAlert class="m-0 p-0" />
     <div v-if="exam">
       <span style="font-size: 1.4rem; font-weight: 600;">Edit Exam Details</span>
+
       <b-form v-if="showAllFields">
+
         <b-form-row v-if="is_liaison_designate && examType === 'group'">
           <OfficeDrop :columnW="10" :office_number="office_number" :setOffice="setOffice" />
         </b-form-row>
+
         <b-form-row>
           <b-col cols="6">
             <b-form-group>
@@ -23,6 +26,7 @@
                             v-model="fields.event_id" />
             </b-form-group>
           </b-col>
+
           <b-col cols="6">
             <b-form-group>
               <label class="my-0">Exam Method</label><br>
@@ -33,6 +37,7 @@
             </b-form-group>
           </b-col>
         </b-form-row>
+
         <b-form-row>
             <b-col>
               <b-form-group v-if="exam.exam_type.ita_ind===1 && examType !== 'challenger' ">
@@ -68,6 +73,7 @@
             </b-form-group>
           </b-col>
         </b-form-row>
+
         <b-form-row>
           <b-col>
             <b-form-group>
@@ -79,7 +85,8 @@
             </b-form-group>
           </b-col>
         </b-form-row>
-        <b-form-row>
+
+        <b-form-row v-if="!otherOfficeExam">
           <b-col :col="!this.fields.exam_received_date" :cols="this.exam_received ? 3 : '' ">
             <b-form-group>
               <label class="my-0">Exam Received?</label>
@@ -90,18 +97,22 @@
                         :options="examReceivedOptions" />
             </b-form-group>
           </b-col>
+
           <b-col v-if="exam_received">
             <b-form-group>
               <label class="my-0">Received Date</label><br>
               <DatePicker :value="fields.exam_received_date"
                           @input="handleDate"
+                          format="YYYY-MM-DD"
+                          value-type="format"
+                          lang="en"
                           id="exam_received_date"
                           input-class="form-control"
-                          class="w-100 my-0 less-10-mb"
-                          lang="en">
+                          class="w-100 my-0 less-10-mb">
               </DatePicker>
             </b-form-group>
           </b-col>
+
           <b-col v-if="examType === 'group' || examType === 'challenger'" col>
             <b-form-group>
               <label class="my-0"># of Writers</label><br>
@@ -109,14 +120,17 @@
                        id="number_of_students" />
             </b-form-group>
           </b-col>
+
           <b-col class="w-100" v-if="examType === 'individual'">
             <b-form-group>
               <label class="my-0">Expiry Date</label><br>
               <DatePicker v-model="fields.expiry_date"
+                          lang="en"
                           id="exam_expiry"
+                          format="YYYY-MM-DD"
+                          value-type="format"
                           input-class="form-control"
-                          class="w-100 less-10-mb"
-                          lang="en">
+                          class="w-100 less-10-mb">
                 <template slot="calendar-icon">
                   <font-awesome-icon icon="clock"
                                      class="m-0 p-0"
@@ -126,6 +140,7 @@
             </b-form-group>
           </b-col>
         </b-form-row>
+
         <b-form-row v-if="examType === 'individual' || examType === 'other'">
           <b-col>
             <b-form-group>
@@ -137,6 +152,7 @@
             </b-form-group>
           </b-col>
         </b-form-row>
+
         <b-form-row>
           <b-col>
             <b-form-group>
@@ -146,6 +162,7 @@
           </b-col>
         </b-form-row>
       </b-form>
+
       <b-form v-if="!showAllFields">
         <b-form-row>
           <b-col class="mb-2">
@@ -177,6 +194,7 @@
             </div>
           </b-col>
         </b-form-row>
+
         <b-form-row>
           <b-col>
             <b-form-group>
@@ -188,11 +206,14 @@
                         v-model="exam_received" />
             </b-form-group>
           </b-col>
+
           <b-col v-if="exam_received" cols="6">
             <b-form-group>
               <label class="my-0">Date Received</label><br>
               <DatePicker v-model="fields.exam_received_date"
                           id="exam_received_date"
+                          format="YYYY-MM-DD"
+                          value-type="format"
                           input-class="form-control"
                           class="w-100 my-0 less-10-mb"
                           type="date"
@@ -200,6 +221,7 @@
             </b-form-group>
           </b-col>
         </b-form-row>
+
         <b-form-row>
           <b-col>
             <b-form-group>
@@ -209,20 +231,22 @@
           </b-col>
         </b-form-row>
       </b-form>
+
       <div v-if="showMessage"
            class="mb-3"
            style="color: red;">{{ this.message }}</div>
+
       <div style="display: flex; justify-content: flex-end; width: 100%">
         <b-btn v-if="is_ita_designate"
                class="btn-danger mr-2"
                @click="deleteExam()">Delete Exam</b-btn>
         <b-btn class="btn-secondary mr-2"
                @click="toggleEditExamModal(false)">Cancel</b-btn>
-        <b-btn v-if="!allowSubmit()"
+        <b-btn v-if="!allowSubmit"
                id="edit_submit_not_allow"
                class="btn-primary disabled"
                @click="setMessage">Submit</b-btn>
-        <b-btn v-else-if="allowSubmit()"
+        <b-btn v-else-if="allowSubmit"
                id="edit_submit_allow"
                class="btn-primary"
                @click="submit">Submit</b-btn>
@@ -274,7 +298,62 @@
                    'examTypes',
                    'offices',
                    'showEditExamModal',
-                   'showDeleteExamModal', ]),
+                   'showDeleteExamModal',
+                   'user', ]),
+      fieldsEdited() {
+        let fieldsEdited = []
+        let data = Object.assign({}, this.fields)
+        if (data.exam_received_date) {
+          data.exam_received_date = moment(data.exam_received_date).utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+        }
+        if (data.expiry_date) {
+          data.expiry_date = moment(data.expiry_date).utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+        }
+        for (let key in data) {
+          if (data[key] != this.actionedExam[key]) {
+            fieldsEdited.push(key)
+          }
+        }
+        if (fieldsEdited.length === 1 && fieldsEdited.includes('notes')) {
+          if (!data.notes && !this.actionedExam.notes) {
+            return false
+          }
+        }
+        return fieldsEdited
+      },
+      allowSubmit() {
+        if (this.actionedExam) {
+          let fieldsEdited = []
+          let data = Object.assign({}, this.fields)
+          if (data.exam_received_date) {
+            data.exam_received_date = moment(data.exam_received_date).utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+          }
+          if (data.expiry_date) {
+            data.expiry_date = moment(data.expiry_date).utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+          }
+          for (let key in data) {
+            if (data[key] != this.actionedExam[key]) {
+              fieldsEdited.push(key)
+            }
+          }
+          if (fieldsEdited.length === 1 && fieldsEdited.includes('notes')) {
+            if (!data.notes && !this.actionedExam.notes) {
+              return false
+            }
+          }
+          return (fieldsEdited.length > 0)
+        }
+        return false
+      },
+      otherOfficeExam() {
+        if (!this.is_liaison_designate) {
+          return false
+        }
+        if (this.actionedExam && this.actionedExam.office_id != this.user.office_id) {
+          return true
+        }
+        return false
+      },
       exam() {
         if (Object.keys(this.actionedExam).length > 0) {
           return this.actionedExam
@@ -365,7 +444,7 @@
         set(e) {
           this.toggleEditExamModal(e)
         }
-      }
+      },
     },
     methods: {
       ...mapActions(['getBookings', 'getExams', 'getOffices', 'putExamInfo',]),
@@ -385,26 +464,8 @@
           date
         )
       },
-      allowSubmit() {
-        if (this.actionedExam) {
-          let fieldsEdited = false
-          let fields = Object.keys(this.fields)
-          for (let key of fields) {
-            if (this.fields[key] != this.actionedExam[key]) {
-              fieldsEdited = true
-              this.showMessage = false
-              break
-            }
-          }
-          return fieldsEdited
-        }
-        return false
-      },
       isITAGropOrSingleExam(ex) {
-        if (ex.exam_type.group_exam_ind || ex.exam_type.exam_type_name.includes('Single') ) {
-          return true
-        }
-        return false
+        return ex.exam_type.ita_ind ? true : false
       },
       deleteExam() {
         let deleteExamInfo = {}
@@ -416,7 +477,7 @@
             examinee_name: this.fields.examinee_name,
             event_id: this.fields.event_id,
           }
-        }else {
+        } else {
           deleteExamInfo = {
             booking_id: null,
             exam_id: this.fields.exam_id,
@@ -440,7 +501,7 @@
       },
       populateForm() {
         let exam = this.actionedExam
-        Object.keys(this.actionedExam).forEach( key => {
+        Object.keys(exam).forEach( key => {
           if (typeof exam[key] === 'string' || typeof exam[key] === 'number') {
             Vue.set(
               this.fields,
@@ -449,10 +510,14 @@
             )
           }
         })
-        this.office_number = exam.office.office_number
-        if (exam.exam_received_date) {
+        if (exam.expiry_date) {
+          this.fields.expiry_date = new moment(exam.expiry_date).format('YYYY-MM-DD')
+        }
+        if (exam.exam_received_date && moment().isValid(exam.exam_received_date)) {
+          this.fields.exam_received_date = new moment(exam.exam_received_date).format('YYYY-MM-DD')
           this.exam_received = true
         }
+        this.office_number = exam.office.office_number
       },
       setOffice(officeNumber) {
         this.office_number = officeNumber
@@ -477,7 +542,7 @@
         this.resetExam()
       },
       setMessage() {
-        if (!this.allowSubmit()) {
+        if (!this.allowSubmit) {
           if (!this.fields.office_id) {
             this.message = 'Please specify a valid office.'
           } else {
@@ -487,15 +552,22 @@
         }
       },
       submit() {
+        let data = Object.assign({}, this.fields)
         let putRequest = {
           exam_id: this.fields.exam_id
         }
-        Object.keys(this.fields).forEach( key => {
-          if (this.fields[key] != this.actionedExam[key]) {
-            putRequest[key] = this.fields[key]
+        if (data.exam_received_date) {
+          data.exam_received_date = moment(data.exam_received_date).utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+        }
+        if (data.expiry_date) {
+          data.expiry_date = moment(data.expiry_date).utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+        }
+        Object.keys(data).forEach( key => {
+          if (data[key] != this.actionedExam[key]) {
+            putRequest[key] = data[key]
           }
         })
-        if (!this.exam_received && this.actionedExam.exam_received_date) {
+        if (!this.exam_received) {
           putRequest['exam_received_date'] = null
         }
         this.putExamInfo(putRequest).then( () => {
@@ -507,11 +579,11 @@
       updateExamReceived(e) {
         let { exam_received_date } = this.fields
         if (e && !exam_received_date) {
-          this.fields['exam_received_date'] = new moment().format('YYYY-MM-DD[T]hh:mm:ssZ')
+          this.fields.exam_received_date = new moment().format('YYYY-MM-DD')
           return
         }
-        if (!e && exam_received_date) {
-          this.fields['exam_received_date'] = null
+        if (!e) {
+          this.fields.exam_received_date = null
         }
       }
     },

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -20,7 +20,7 @@
       </b-form>
       <div style="display:flex; justify-content: space-between">
         <b-button class="mr-2 btn-secondary"
-                  @click="setFilter({type: 'office_number', value: 'default'})">This Office</b-button>
+                  @click="setHomeOffice">This Office</b-button>
         <b-button class="ml-2 btn-primary"
                   @click="officeFilterModal=false">Ok</b-button>
       </div>
@@ -642,6 +642,10 @@
       },
       setOfficeFilter(office_number) {
         this.setFilter({type:'office_number', value: office_number})
+      },
+      setHomeOffice() {
+        this.setFilter({type: 'office_number', value: 'default'})
+        this.officeFilterModal = false
       },
       sortCompare(a, b, key) {
         if (key === 'scheduled') {

--- a/frontend/src/layout/nav.vue
+++ b/frontend/src/layout/nav.vue
@@ -34,7 +34,7 @@
            style="flex-grow: 8"
            class="q-inline-title">{{ calendarSetup.title }}</div>
     <div />
-      <div v-if="!scheduling && !rescheduling">
+      <div v-if="!scheduling && !rescheduling && !citizenInvited">
         <b-dropdown variant="outline-primary"
                     class="pl-0 ml-0 mr-3"
                     right
@@ -95,6 +95,7 @@
         'showAppointments'
       ]),
       ...mapState([
+        'citizenInvited',
         'showServiceModal',
         'calendarSetup',
         'rescheduling',

--- a/frontend/src/serve-citizen/serve-citizen.vue
+++ b/frontend/src/serve-citizen/serve-citizen.vue
@@ -16,13 +16,11 @@
               {{ simplifiedModal ? 'Exams Time Tracking' : 'Serve Citizen' }}</h4>
           </div>
           <div>
-            <button
-                      class="btn btn-link"
-                      @click="toggleFeedback">Feedback</button>
-            <button
-                      class="btn btn-link"
-                      style="margin-left: 20px"
-                      @click="toggleMinimize">{{ minimizeWindow ? "Maximize" : "Minimize" }}</button>
+            <button class="btn btn-link"
+                    @click="toggleFeedback">Feedback</button>
+            <button class="btn btn-link"
+                    style="margin-left: 20px"
+                    @click="toggleMinimize">{{ minimizeWindow ? "Maximize" : "Minimize" }}</button>
           </div>
         </div>
         <template v-if="!simplifiedModal">

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -49,7 +49,6 @@ export const store = new Vuex.Store({
       priority: 2
     },
     addModalSetup: null,
-    nonITAExam: false,
     addNextService: false,
     adminNavigation: 'csr',
     appointmentsStateInfo: {
@@ -82,24 +81,19 @@ export const store = new Vuex.Store({
     dismissCount: 0,
     editedBooking: null,
     editedBookingOriginal: null,
-    editExamFailureCount: 0,
     editedGroupBooking: null,
+    editExamFailureCount: 0,
     editExamSuccessCount: 0,
     examAlertMessage: '',
-    loginAlertMessage: '',
-    examEditSuccessMessage: '',
-    examEditFailureMessage: '',
     examDismissCount: 0,
-    loginDismissCount: 0,
+    examEditFailureMessage: '',
+    examEditSuccessMessage: '',
+    exams: [],
     examsTrackingIP: false,
     examSuccessDismiss : 0,
-    exams: [],
     examTypes: [],
     feedbackMessage: '',
-    showGenFinReportModal: false,
     iframeLogedIn: false,
-    invigilators: [],
-    isLoggedIn: false,
     inventoryFilters: {
       expiryFilter: 'current',
       scheduledFilter: 'both',
@@ -107,16 +101,21 @@ export const store = new Vuex.Store({
       returnedFilter: 'unreturned',
       office_number: 'default',
     },
+    invigilators: [],
+    isLoggedIn: false,
+    loginAlertMessage: '',
+    loginDismissCount: 0,
+    nonITAExam: false,
     nowServing: false,
-    offices: [],
     officeFilter: null,
+    offices: [],
     officeType: null,
     offsiteVisible: true,
     performingAction: false,
     rescheduling: false,
     returnExam: null,
-    rooms: [],
     roomResources: [],
+    rooms: [],
     scheduling: false,
     selectedExam: {},
     selectedOffice: {},
@@ -140,16 +139,17 @@ export const store = new Vuex.Store({
     showBookingModal: false,
     showDeleteExamModal: false,
     showEditBookingModal: false,
-    showEditGroupBookingModal: false,
     showEditExamModal: false,
+    showEditGroupBookingModal: false,
     showExamInventoryModal: false,
     showFeedbackModal: false,
     showGAScreenModal: false,
-    showSelectInvigilatorModal: false,
-    showServeCitizenSpinner: false,
+    showGenFinReportModal: false,
     showOtherBookingModal: false,
     showResponseModal: false,
     showReturnExamModal: false,
+    showSelectInvigilatorModal: false,
+    showServeCitizenSpinner: false,
     showServiceModal: false,
     user: {
       csr_id: null,
@@ -968,6 +968,7 @@ export const store = new Vuex.Store({
     },
   
     clickBeginService(context, payload) {
+      context.commit('toggleServeCitizenSpinner', true)
       let { citizen_id } = context.getters.form_data.citizen
       context.commit('setPerformingAction', true)
     
@@ -1132,6 +1133,7 @@ export const store = new Vuex.Store({
     },
 
     clickInvite(context) {
+      context.commit('toggleServeCitizenSpinner', true)
       context.commit('setPerformingAction', true)
 
       context.dispatch('postInvite', 'next').then(() => {
@@ -1235,6 +1237,7 @@ export const store = new Vuex.Store({
     },
 
     clickRowHoldQueue(context, citizen_id) {
+      context.commit('toggleServeCitizenSpinner', true)
       context.commit('setPerformingAction', true)
 
       context.dispatch('postBeginService', citizen_id).then( () => {
@@ -1245,7 +1248,7 @@ export const store = new Vuex.Store({
         context.commit('setPerformingAction', false)
       })
     },
-
+    
     toggleBegunStatus({commit}) {
       commit('toggleBegunStatus', payload)
     },
@@ -1649,16 +1652,16 @@ export const store = new Vuex.Store({
         }
         delete responses.on_or_off
       }
-      
+      responses.office_id = responses.office_id ? responses.office_id : context.state.user.office_id
       let defaultValues = {
         exam_returned_ind: 0,
-        number_of_students: 1,
-        office_id: context.state.user.office_id
+        number_of_students: 1
       }
-      if (context.state.addExamModal.setup === 'pesticide') {
-        defaultValues.office_id = responses['office_id']
+      let exp = new moment(responses.expiry_date).format('YYYY-MM-DD').toString()
+      responses.expiry_date = new moment(exp).utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+      if (responses.exam_received_date) {
+        responses.exam_received_date = new moment(responses.exam_received_date).utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
       }
-      responses.expiry_date = moment(responses.expiry_date).format('YYYY-MM-DD')
       if (responses.notes === null) {
         responses.notes = ''
       }
@@ -2409,6 +2412,8 @@ export const store = new Vuex.Store({
   
     clearAddExamModalFromCalendarStatus: state => Vue.delete(state.addExamModal, 'fromCalendar'),
   
-    toggleServeCitizenSpinner: (state, payload) => state.showServeCitizenSpinner = payload,
+    toggleServeCitizenSpinner(state, payload) {
+      state.showServeCitizenSpinner = payload
+    },
   }
 })


### PR DESCRIPTION
* Updated finance reporting now that individual exams can be booked offsite
* Financial Reporting - Filtering Offices
Clients asked that if a user is a financial reporting designate to return ALL exams when the query for reporting is submited. Otherwise the exams returned to the user are filtered based upon the users office.

* Fix Edit Exam Modal: Date Received / Expiry Date Inconsistency

App was inconsistent with formatting/parsing of dates at capture, display and during POST/PUT actions.  All dates now captured in local time, submitted as UTC and converted to local time for display.  This eliminates the issue where DatePickers were showing the day before the actual date value held in the backend/store

* Fixed Issue w/ the Q where CSR able to navigate away when serving citizen

Added condition to display of hamburger menu to prevent this from happening

* Fix Serve Citizen Modal Loading Spinner

Previously added trigger to show the spinner when clicking on a citizen from the queue table but failed to consider the scenarios of clicking on a citizen in the hold table or directly from the Add Citizen Modal.  Added triggers for the other ways to launch the modal.

* Group Exam Notifications - SBC Staff

Clients noticed after production release that group exams were causing the notification banner to show if SBC Staff were selected as invigilators. This condition met the requirements of not having to notify staff about exams, and such was fixed by adding a filter the group exam object in the csrs/me endpoint that only counted exams with booking.sbc_staff_invigilated == 0. This was tested by creating a group exam object, then creating a booking for this exams without an inviglator and making sure the notification would present itself on refresh. Then, altering the booking to have SBC staff invigilate the booking, refreshing the page to make sure no notification was present. Finally, the booking was altered to have an actual invigilator present for the booking, and refreshing the page to make sure that the notification banner was not present.