### PR TITLE
Phase 1 - Active Citizen Count Requirements Fix

### DIFF
--- a/frontend/src/Login.vue
+++ b/frontend/src/Login.vue
@@ -133,7 +133,7 @@ import { mapActions, mapGetters, mapMutations, mapState } from 'vuex'
         return this.citizens_queue.length
       },
       citizenSBType() {
-        if(this.user.office.sb.sb_type === 'nocallonsmartboard'){
+        if(this.user.office.sb.sb_type !== 'nocallonsmartboard'){
           return true
         }
         else {


### PR DESCRIPTION
Client asked for the SB Detection function to look for smartboards that are not 'nocallonsmartboard', and not the converse. This was addressed by modifying the comparator in the citizenSBType function on the login component.