### PR TITLE
Phase 1 - Exam Booking Contact Information

### DIFF
--- a/frontend/src/booking/booking-modal.vue
+++ b/frontend/src/booking/booking-modal.vue
@@ -423,6 +423,7 @@
               })
             })
           })
+          this.booking_contact_information = ''
         })
       }
     },


### PR DESCRIPTION
Clients noted that when booking multiple back-to-back exam events in the bookings calendar, that the contact information from previous bookings would carry forward.

This bug was resolved by setting the contact information variable for the booking modal to be an empty string after the POST was completed.