### PR TITLE
Phase 1 - Notification Banner and Exam Inventory Filter Updates

### DIFF
--- a/frontend/src/exam-alert.vue
+++ b/frontend/src/exam-alert.vue
@@ -13,14 +13,21 @@ See the License for the specific language governing permissions and
 limitations under the License.*/
 
 <template>
-  <div v-if="is_ita_designate" id="EXAMALERT">
+  <div v-if="is_ita_designate"
+       id="EXAMALERT">
     <b-alert
              variant="primary"
              dismissible
              :show="examDismissCount"
              style="h-align: center; font-size:1rem; border-radius: 0px;"
              @dismissed="onDismissedExam">
-             {{ examAlertMessage }}
+      Office Exam Manager Action Items are Present
+      <b-button id="showExams"
+                variant="primary"
+                @click="goShow"
+                size="sm">
+        Show
+      </b-button>
     </b-alert>
   </div>
 </template>
@@ -32,14 +39,56 @@ export default {
   name: 'ExamAlert',
   computed: {
     ...mapGetters([ 'is_ita_designate' ]),
-    ...mapState([ 'examAlertMessage', 'examDismissCount' ])
+    ...mapState([ 'examDismissCount',
+                  'groupExam',
+                  'groupIndividualExam',
+                  'individualExam'])
   },
   methods: {
-    ...mapMutations(['examDismissCountDown']),
-
+    ...mapMutations(['examDismissCountDown',
+                     'setInventoryFilters',
+                     'setSelectedExamType',
+                     'setSelectedExamTypeFilter',
+                     'setSelectedQuickAction',
+                     'setSelectedQuickActionFilter',]),
+    goShow() {
+      this.$router.push('/exams')
+      if(this.groupIndividualExam){
+        this.setSelectedExamType('all')
+        this.setSelectedExamTypeFilter('All')
+        this.setSelectedQuickAction('oemai')
+        this.setSelectedQuickActionFilter('Office Exam Manager Exam Items')
+        this.setInventoryFilters({type:'groupFilter', value:'both'})
+        this.setInventoryFilters({type:'requireOEMAttentionFilter', value:'both'})
+      }
+      else if(this.groupExam && !this.individualExam){
+        this.setSelectedExamType('group')
+        this.setSelectedExamTypeFilter('Group')
+        this.setSelectedQuickAction('oemai')
+        this.setSelectedQuickActionFilter('Office Exam Manager Exam Items')
+        this.setInventoryFilters({type:'groupFilter', value:'group'})
+        this.setInventoryFilters({type:'requireAttentionFilter', value:'both'})
+      }
+      else if(!this.groupExam && this.individualExam){
+        this.setSelectedExamType('individual')
+        this.setSelectedExamTypeFilter('Individual')
+        this.setSelectedQuickAction('oemai')
+        this.setSelectedQuickActionFilter('Office Exam Manager Exam Items')
+        this.setInventoryFilters({type:'groupFilter', value:'individual'})
+        this.setInventoryFilters({type:'requireOEMAttentionFilter', value: 'both'})
+      }
+    },
     onDismissedExam() {
       this.examDismissCountDown(999)
     }
   }
 }
 </script>
+
+<style>
+  #showExams {
+    position: relative;
+    float: right;
+    bottom: 6px;
+  }
+</style>

--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -25,85 +25,96 @@
                   @click="officeFilterModal=false">Ok</b-button>
       </div>
     </b-modal>
-    <div class="q-w100-flex-fs">
-      <b-form inline class="ml-3">
-        <b-input-group>
-          <b-input-group-prepend><label class="mx-1 pt-1 my-auto label-text">Search</label></b-input-group-prepend>
-          <b-input size="sm" class="mb-1 mt-3" v-model="searchTerm"></b-input>
-        </b-input-group>
-        <b-input-group class="ml-3" v-if="!showExamInventoryModal">
-          <b-input-group-prepend>
-            <label class="mx-1 pt-1 my-auto label-text">Filters</label>
-          </b-input-group-prepend>
-          <b-btn-group v-if="is_liaison_designate" class="pt-2">
-            <b-btn @click="officeFilterModal=true"
-                   :variant="officeFilter === userOffice || officeFilter === 'default' ? 'primary' : 'warning'"
-                   class="btn-sm">Office # {{ officeNumber }} - {{ officeName }}</b-btn>
-          </b-btn-group>
-          <b-button-group horizontal
-                          class="ml-2 pt-2"
-                          label="Expired Exam Filters">
-            <b-button size="sm"
-                      :pressed="inventoryFilters.expiryFilter==='all'"
-                      @click="setInventoryFilters({type:'expiryFilter', value:'all'})"
-                      variant="primary">
-              <span class="mx-2">All</span>
-            </b-button>
-            <b-button size="sm"
-                      :pressed="inventoryFilters.expiryFilter==='expired'"
-                      @click="setInventoryFilters({type:'expiryFilter', value:'expired'})"
-                      variant="primary">Expired</b-button>
-            <b-button size="sm"
-                      :pressed="inventoryFilters.expiryFilter==='current'"
-                      @click="setInventoryFilters({type:'expiryFilter', value:'current'})"
-                      variant="primary">Current</b-button>
-          </b-button-group>
-          <b-btn-group horizontal class="ml-2 pt-2">
-            <b-btn size="sm"
-                   :pressed="inventoryFilters.scheduledFilter==='both'"
-                   @click="setInventoryFilters({type:'scheduledFilter', value:'both'})"
-                   variant="primary">
-              <span class="mx-2">Both</span>
-            </b-btn>
-            <b-btn size="sm"
-                   :pressed="inventoryFilters.scheduledFilter==='unscheduled'"
-                   @click="setInventoryFilters({type:'scheduledFilter', value:'unscheduled'})"
-                   variant="primary">Not Ready</b-btn>
-            <b-btn size="sm"
-                   :pressed="inventoryFilters.scheduledFilter==='scheduled'"
-                   @click="setInventoryFilters({type:'scheduledFilter', value:'scheduled'})"
-                   variant="primary">Ready</b-btn>
-          </b-btn-group>
-          <b-btn-group horizontal class="ml-2 pt-2">
-            <b-btn size="sm"
-                   :pressed="inventoryFilters.groupFilter==='both'"
-                   @click="setInventoryFilters({type:'groupFilter', value:'both'})"
-                   variant="primary"><span class="mx-2">Both</span></b-btn>
-            <b-btn size="sm"
-                   :pressed="inventoryFilters.groupFilter==='individual'"
-                   @click="setInventoryFilters({type:'groupFilter', value:'individual'})"
-                   variant="primary">Individual</b-btn>
-            <b-btn size="sm"
-                   :pressed="inventoryFilters.groupFilter==='group'"
-                   @click="setInventoryFilters({type:'groupFilter', value:'group'})"
-                   variant="primary">Group</b-btn>
-          </b-btn-group>
-          <b-btn-group horizontal class="ml-2 pt-2">
-            <b-btn size="sm"
-                   :pressed="inventoryFilters.returnedFilter==='both'"
-                   @click="setFilter({type:'returnedFilter', value:'both'})"
-                   variant="primary"><span class="mx-2">Both</span></b-btn>
-            <b-btn size="sm"
-                   :pressed="inventoryFilters.returnedFilter==='returned'"
-                   @click="setFilter({type:'returnedFilter', value:'returned'})"
-                   variant="primary">Returned</b-btn>
-            <b-btn size="sm"
-                   :pressed="inventoryFilters.returnedFilter==='unreturned'"
-                   @click="setFilter({type:'returnedFilter', value:'unreturned'})"
-                   variant="primary">Not Returned</b-btn>
-          </b-btn-group>
-        </b-input-group>
-      </b-form>
+    <div style="display: flex; justify-content: space-between" class="q-w100-flex-fs">
+      <div>
+        <b-form inline class="ml-3">
+        <!-- TODO Pagination Left goes here if required-->
+          <b-input-group>
+            <b-input-group-prepend><label class="mx-1 pt-3 ml-2 my-auto label-text">Search</label></b-input-group-prepend>
+            <b-input size="sm" class="mb-1 mt-3" v-model="searchTerm"></b-input>
+          </b-input-group>
+          <b-input-group class="ml-3" v-if="!showExamInventoryModal">
+            <b-input-group-prepend>
+              <label class="mx-1 pt-3 mr-2 my-auto label-text">Filters</label>
+            </b-input-group-prepend>
+            <b-btn-group v-if="is_liaison_designate" class="pt-2">
+              <b-btn @click="officeFilterModal=true"
+                     :variant="officeFilter === userOffice || officeFilter === 'default' ? 'primary' : 'warning'"
+                     class="btn-sm mr-2">Office # {{ officeNumber }} - {{ officeName }}</b-btn>
+            </b-btn-group>
+          </b-input-group>
+          <b-input-group>
+            <b-btn-group v-if="selectedExamTypeFilter === ''">
+              <b-dropdown size="sm"
+                          variant="primary"
+                          text="Exam Type Filters"
+                          v-model="selectedExamTypeFilter"
+                          class="mt-2 mr-2">
+                <b-dropdown-item v-for="option in examTypeOptions"
+                                 @click="setExamTypeFilter(option)">
+                  {{ option.text }}
+                </b-dropdown-item>
+              </b-dropdown>
+            </b-btn-group>
+            <b-btn-group v-else>
+              <b-dropdown size="sm"
+                          variant="primary"
+                          :text="this.selectedExamTypeFilter"
+                          v-model="selectedExamTypeFilter"
+                          class="mt-2 mr-2">
+                <b-dropdown-item v-for="option in examTypeOptions"
+                                 @click="setExamTypeFilter(option)">
+                  {{ option.text }}
+                </b-dropdown-item>
+              </b-dropdown>
+            </b-btn-group>
+            <b-btn-group v-if="selectedQuickActionFilter === ''">
+              <b-dropdown size="sm"
+                          variant="primary"
+                          text="Quick Action Filters"
+                          v-model="selectedQuickActionFilter"
+                          class="mt-2 mr-2">
+                <b-dropdown-item v-for="option in newQuickActionOptions"
+                                 @click="setQuickActionFilter(option)">
+                  <div style="display: flex; justify-content: space-between;">
+                    <div class="mr-3">{{ option.text }}</div>
+                    <div v-if="option.text === 'Ready'">
+                      <font-awesome-icon icon='clipboard-check'
+                                         style="fontSize: 1rem; color: green;"/>
+                    </div>
+                    <div v-if="option.text === 'Requires Attention'">
+                      <font-awesome-icon icon='life-ring'
+                                         style="fontSize: 1rem; color: red;"/>
+                      <font-awesome-icon icon='exclamation-triangle'
+                                         style="fontSize: 1rem; color: #FFC32B;"/>
+                    </div>
+                  </div>
+                </b-dropdown-item>
+              </b-dropdown>
+            </b-btn-group>
+            <b-btn-group v-else>
+              <b-dropdown size="sm"
+                          variant="primary"
+                          :text="this.selectedQuickActionFilter"
+                          v-model="selectedQuickActionFilter"
+                          class="mt-2 mr-2">
+                <b-dropdown-item v-for="option in newQuickActionOptions"
+                                 @click="setQuickActionFilter(option)">
+                  {{ option.text }}
+                </b-dropdown-item>
+              </b-dropdown>
+            </b-btn-group>
+          </b-input-group>
+        </b-form>
+      </div>
+      <div>
+        <b-pagination :total-rows="totalRows"
+                    :per-page="10"
+                    v-if="filteredExams().length > 10"
+                    v-model="page"
+                    class="mb-0 pt-2 mr-4 mt-1"
+                    style="display: flex; justify-content: flex-end;"/>
+      </div>
     </div>
     <div :style="tableStyle" class="my-0 mx-3">
       <b-table :items="filteredExams()"
@@ -133,9 +144,15 @@
           {{ row.item.exam_type.exam_type_name }}
         </template>
 
+        <template slot="start_time" slot-scope="row">
+          <span v-if="!row.item.booking"> - </span>
+          <span v-else> {{ formatDate(row.item.booking.start_time) }}</span>
+        </template>
+
         <template slot="expiry_date" slot-scope="row">
-          <span v-if="row.item.exam_type.exam_type_name === 'Monthly Session Exam'">–</span>
-          <span v-else-if="row.item.exam_type.group_exam_ind">–</span>
+          <span v-if="row.item.exam_type.exam_type_name === 'Monthly Session Exam' && !checkExpiryDate(row.item.expiry_date)">–</span>
+          <span v-else-if="row.item.exam_type.group_exam_ind && !checkExpiryDate(row.item.expiry_date)">–</span>
+          <span v-else-if="checkExpiryDate(row.item.expiry_date)" class="expired">{{ formatDate(row.item.expiry_date) }}</span>
           <span v-else>{{ formatDate(row.item.expiry_date) }}</span>
         </template>
 
@@ -266,10 +283,6 @@
         </template>
       </b-table>
     </div>
-    <b-pagination :total-rows="totalRows"
-                  :per-page="10"
-                  v-if="filteredExams().length > 10"
-                  v-model="page" />
   </fragment>
 </template>
 
@@ -319,6 +332,19 @@
         buttonH: 45,
         qLengthH: 28,
         totalH: 0,
+        examTypeOptions: [
+          {text: 'Individual', value: 'individual'},
+          {text: 'Group', value: 'group'},
+          {text: 'All', value: 'all'},
+        ],
+        newQuickActionOptions: [
+          {text: 'Ready', value: 'ready'},
+          {text: 'Requires Attention', value:'require_attention'},
+          {text: 'Office Exam Manager Action Items', value:'oemai'},
+          {text: 'Expired', value: 'expired'},
+          {text: 'Returned', value: 'returned'},
+          {text: 'All', value: 'all'},
+        ],
       }
     },
     computed: {
@@ -329,6 +355,10 @@
         'calendarEvents',
         'exams',
         'inventoryFilters',
+        'selectedExamType',
+        'selectedExamTypeFilter',
+        'selectedQuickAction',
+        'selectedQuickActionFilter',
         'showDeleteExamModal',
         'showEditExamModal',
         'showExamInventoryModal',
@@ -346,6 +376,7 @@
             { key: 'event_id', label: 'Event ID', sortable: false, thStyle: 'width: 6%' },
             { key: 'exam_type_name', label: 'Exam Type', sortable: true },
             { key: 'exam_name', label: 'Exam Name', sortable: true, thStyle: 'width: 11%' },
+            { key: 'start_time', label: 'Scheduled Date', sortable: true, thStyle: 'width: 9%' },
             { key: 'exam_method', label: 'Method', sortable: false, thStyle: 'width: 5%' },
             { key: 'expiry_date', label: 'Expiry Date', sortable: true, thStyle: 'width: 8%' },
             { key: 'exam_received', label: 'Received?', sortable: true, thStyle: 'width: 5%' },
@@ -360,6 +391,7 @@
             { key: 'event_id', label: 'Event ID', sortable: false, thStyle: 'width: 6%' },
             { key: 'exam_type.exam_type_name', label: 'Exam Type', sortable: true},
             { key: 'exam_name', label: 'Exam Name', sortable: true, thStyle: 'width: 15%' },
+            { key: 'booking.start_time', label: 'Scheduled Date', sortable: true, thStyle: 'width: 9%' },
             { key: 'exam_method', label: 'Method', sortable: true, thStyle: 'width: 5%' },
             { key: 'expiry_date', label: 'Expiry Date', sortable: true, thStyle: 'width: 8%' },
             { key: 'exam_received', label: 'Received?', sortable: true, thStyle: 'width: 5%' },
@@ -421,6 +453,10 @@
         'setEditExamInfo',
         'setInventoryFilters',
         'setSelectedExam',
+        'setSelectedExamType',
+        'setSelectedExamTypeFilter',
+        'setSelectedQuickAction',
+        'setSelectedQuickActionFilter',
         'toggleDeleteExamModal',
         'toggleEditBookingModal',
         'toggleEditExamModal',
@@ -470,12 +506,26 @@
         }
         return false
       },
+      examReturnedAttention(item){
+        if (item.exam_returned_date ){
+          return true
+        }
+        return false
+      },
       filterByGroup(ex) {
         if (ex.exam_type.exam_type_name === 'Monthly Session Exam' || ex.exam_type.group_exam_ind) {
           return true
         }
         if (ex.number_of_students && parseInt(ex.number_of_students) > 1) {
           return true
+        }
+        return false
+      },
+      filterByExpiry(ex){
+        if (moment(ex.expiry_date).isValid()){
+          if (moment(ex.expiry_date).isBefore(moment(), 'day')) {
+            return true
+          }
         }
         return false
       },
@@ -497,6 +547,47 @@
         }
         return false
       },
+      checkAllAttention(ex) {
+        if(this.examReturnedAttention(ex)){
+          return false
+        }
+        if(this.filterByGroup(ex)){
+            return !this.filterByScheduled(ex)
+        }else {
+          if(this.filterByExpiry(ex)){
+            return true
+          }
+        }
+        return false
+      },
+      checkExpiryDate(date){
+        if(moment(date).isValid() && moment(date).isBefore(moment(), 'day')){
+          return true
+        }
+        return false
+      },
+      checkOEMAttention(ex) {
+        if(this.filterByGroup(ex)){
+          if(moment(ex.booking.start_time).isValid()){
+            if(moment(ex.booking.start_time).isBefore(moment(), 'day')){
+              if(!this.examReturnedAttention(ex)){
+                return true
+              }
+              return false
+            }
+          }
+          if(ex.booking && (ex.booking.invigilator_id || ex.booking.sbc_staff_invigilated)){
+            return false
+          }else if(ex.booking && (!ex.booking.invigilator_id || !ex.booking.sbc_staff_invigilated)) {
+            return true
+          }
+        }else {
+          if(this.filterByExpiry(ex) && !this.examReturnedAttention(ex)){
+            return true
+          }
+        }
+        return false
+      },
       filteredExams() {
         let examInventory = this.exam_inventory
         let office_number = this.inventoryFilters.office_number === 'default' ?
@@ -511,6 +602,12 @@
             return evenMoreFiltered.filter(ex => ex.office_id == office_id)
           }
           let exams = examInventory.filter(ex => ex.office.office_number == office_number)
+          if(this.inventoryFilters.requireAttentionFilter === 'both'){
+            return exams.filter(ex => this.checkAllAttention(ex))
+          }
+          if(this.inventoryFilters.requireOEMAttentionFilter === 'both'){
+            return exams.filter(ex => this.checkOEMAttention(ex))
+          }
           switch (this.inventoryFilters.expiryFilter) {
             case 'all':
               filtered = exams
@@ -616,10 +713,6 @@
           if (item.booking.room_id) {
             output.Room = item.booking.room.room_name
           }
-          if (item.booking.start_time) {
-            output.Date = this.formatDate(item.booking.start_time)
-            output.Time = this.formatTime(item.booking)
-          }
         }
         return output
       },
@@ -634,6 +727,95 @@
       returnExam(item) {
         this.actionedExam = item
         this.toggleReturnExamModal(true)
+      },
+      setExamTypeFilter(option){
+        this.setSelectedExamType(option.value)
+        this.setSelectedExamTypeFilter(option.text)
+
+        if(option.value === 'individual'){
+          this.setSelectedQuickAction('')
+          this.setSelectedQuickActionFilter('')
+          this.setInventoryFilters({type:'groupFilter', value:'individual'})
+          this.setInventoryFilters({type:'expiryFilter', value:'all'})
+          this.setInventoryFilters({type:'returnedFilter', value:'both'})
+          this.setInventoryFilters({type:'scheduledFilter', value:'both'})
+          this.setInventoryFilters({type:'requireAttentionFilter', value:'default'})
+        }else if (option.value === 'group'){
+          this.setSelectedQuickAction('')
+          this.setSelectedQuickActionFilter('')
+          this.setInventoryFilters({type:'groupFilter', value:'group'})
+          this.setInventoryFilters({type:'expiryFilter', value:'all'})
+          this.setInventoryFilters({type:'returnedFilter', value:'both'})
+          this.setInventoryFilters({type:'scheduledFilter', value:'both'})
+          this.setInventoryFilters({type:'requireAttentionFilter', value:'default'})
+        }else if (option.value === 'all'){
+          this.setSelectedQuickAction('')
+          this.setSelectedQuickActionFilter('')
+          this.setInventoryFilters({type:'expiryFilter', value:'all'})
+          this.setInventoryFilters({type:'returnedFilter', value:'both'})
+          this.setInventoryFilters({type:'scheduledFilter', value:'both'})
+          this.setInventoryFilters({type:'requireAttentionFilter', value:'default'})
+          this.setInventoryFilters({type:'groupFilter', value:'both'})
+        }
+      },
+      setQuickActionFilter(option){
+        this.setSelectedQuickAction(option.value)
+        this.setSelectedQuickActionFilter(option.text)
+        if(option.value === 'returned'){
+          this.setInventoryFilters({type:'returnedFilter', value:'returned'})
+          this.setInventoryFilters({type:'expiryFilter', value:'all'})
+          this.setInventoryFilters({type:'scheduledFilter', value:'both'})
+          this.setInventoryFilters({type:'requireAttentionFilter', value:'default'})
+          this.setInventoryFilters({type:'requireOEMAttentionFilter', value: 'default'})
+        }else if(option.value === 'require_attention') {
+          if (this.selectedExamType === 'individual') {
+            this.setInventoryFilters({type: 'returnedFilter', value: 'unreturned'})
+            this.setInventoryFilters({type: 'expiryFilter', value: 'expired'})
+            this.setInventoryFilters({type: 'scheduledFilter', value: 'both'})
+            this.setInventoryFilters({type: 'requireAttentionFilter', value: 'default'})
+            this.setInventoryFilters({type:'requireOEMAttentionFilter', value: 'default'})
+          } else if (this.selectedExamType === 'group') {
+            this.setInventoryFilters({type: 'returnedFilter', value: 'unreturned'})
+            this.setInventoryFilters({type: 'expiryFilter', value: 'current'})
+            this.setInventoryFilters({type: 'scheduledFilter', value: 'unscheduled'})
+            this.setInventoryFilters({type: 'requireAttentionFilter', value: 'default'})
+            this.setInventoryFilters({type:'requireOEMAttentionFilter', value: 'default'})
+          } else if (this.selectedExamType === 'all') {
+            this.setInventoryFilters({type: 'requireAttentionFilter', value: 'both'})
+            this.setInventoryFilters({type:'requireOEMAttentionFilter', value: 'default'})
+          }
+        }
+        else if(option.value === 'ready'){
+          this.setInventoryFilters({type:'expiryFilter', value:'current'})
+          this.setInventoryFilters({type:'returnedFilter', value:'unreturned'})
+          this.setInventoryFilters({type:'scheduledFilter', value:'scheduled'})
+          this.setInventoryFilters({type:'requireAttentionFilter', value:'default'})
+          this.setInventoryFilters({type:'requireOEMAttentionFilter', value: 'default'})
+        }else if(option.value === 'expired'){
+          this.setInventoryFilters({type:'expiryFilter', value:'expired'})
+          this.setInventoryFilters({type:'returnedFilter', value:'both'})
+          this.setInventoryFilters({type:'scheduledFilter', value:'both'})
+          this.setInventoryFilters({type:'requireAttentionFilter', value:'default'})
+          this.setInventoryFilters({type:'requireOEMAttentionFilter', value: 'default'})
+        }else if(option.value === 'oemai'){
+          if(this.selectedExamType === 'individual'){
+            this.setInventoryFilters({type:'returnedFilter', value:'unreturned'})
+            this.setInventoryFilters({type:'expiryFilter', value:'expired'})
+            this.setInventoryFilters({type:'scheduledFilter', value:'both'})
+            this.setInventoryFilters({type:'requireAttentionFilter', value:'default'})
+            this.setInventoryFilters({type:'requireOEMAttentionFilter', value: 'default'})
+          }else if(this.selectedExamType === 'group'){
+            this.setInventoryFilters({type:'requireOEMAttentionFilter', value: 'both'})
+          }else if(this.selectedExamType === 'all'){
+            this.setInventoryFilters({type:'requireOEMAttentionFilter', value: 'both'})
+          }
+        }else if(option.value === 'all'){
+          this.setInventoryFilters({type: 'expiryFilter', value: 'all'})
+          this.setInventoryFilters({type:'scheduledFilter', value:'both'})
+          this.setInventoryFilters({type:'returnedFilter', value:'both'})
+          this.setInventoryFilters({type:'requireAttentionFilter', value:'default'})
+          this.setInventoryFilters({type:'requireOEMAttentionFilter', value: 'default'})
+        }
       },
       setFilter(e) {
         this.setInventoryFilters(e)
@@ -790,6 +972,9 @@
     font-size: .85rem !important;
     color: #007bff !important;
     font-weight: 300 !important;
+  }
+  .expired {
+    color: red;
   }
   .view-details-link {
     text-decoration: #007bff underline !important;

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -96,6 +96,7 @@ export const store = new Vuex.Store({
     examSuccessDismiss : 0,
     examTypes: [],
     feedbackMessage: '',
+    groupIndividualExam: false,
     iframeLogedIn: false,
     inventoryFilters: {
       expiryFilter: 'current',
@@ -103,6 +104,8 @@ export const store = new Vuex.Store({
       groupFilter: 'both',
       returnedFilter: 'unreturned',
       office_number: 'default',
+      requireAttentionFilter: 'default',
+      requireOEMAttentionFilter: 'default',
     },
     invigilators: [],
     isLoggedIn: false,
@@ -122,6 +125,10 @@ export const store = new Vuex.Store({
     rooms: [],
     scheduling: false,
     selectedExam: {},
+    selectedExamType: '',
+    selectedExamTypeFilter: '',
+    selectedQuickAction: '',
+    selectedQuickActionFilter: '',
     selectedOffice: {},
     selectionIndicator: false,
     serveModalAlert: '',
@@ -787,7 +794,15 @@ export const store = new Vuex.Store({
             c => c.counter_name === DEFAULT_COUNTER_NAME)[0])
           let individualExamBoolean = false
           let groupExamBoolean = false
-          
+          let groupIndividualBoolean = false
+
+          if(resp.data.group_individual_attention > 0){
+            groupIndividualBoolean = true
+            context.commit('setGroupIndividualExam', groupIndividualBoolean)
+          }else{
+            context.commit('setGroupIndividualExam', groupIndividualBoolean)
+          }
+
           if (resp.data.group_exams > 0) {
             groupExamBoolean = true
             context.commit('setGroupExam', groupExamBoolean)
@@ -808,6 +823,8 @@ export const store = new Vuex.Store({
             context.commit('setExamAlert', 'There are Group Exams that require attention')
           }else if (individualExamBoolean) {
             context.commit('setExamAlert', 'There are Individual Exams that require attention')
+          }else if (groupIndividualBoolean){
+            context.commit('setExamAlert', '')
           }
 
           if (resp.data.active_citizens && resp.data.active_citizens.length > 0) {
@@ -2348,6 +2365,8 @@ export const store = new Vuex.Store({
     setUserLoadingFail: (state, payload) => state.userLoadingFail = payload,
   
     setGroupExam: (state, payload) => state.groupExam = payload,
+
+    setGroupIndividualExam: (state, payload) => state.groupIndividualExam = payload,
   
     setIndividualExam: (state, payload) => state.individualExam = payload,
   
@@ -2530,7 +2549,15 @@ export const store = new Vuex.Store({
     setInventoryFilters(state, payload) {
       state.inventoryFilters[payload.type] = payload.value
     },
-  
+
+    setSelectedExamType: (state, payload) => state.selectedExamType = payload,
+
+    setSelectedExamTypeFilter: (state, payload) => state.selectedExamTypeFilter = payload,
+
+    setSelectedQuickAction: (state, payload) => state.selectedQuickAction = payload,
+
+    setSelectedQuickActionFilter: (state, payload) => state.selectedQuickActionFilter = payload,
+
     restoreSavedModal(state, payload) {
       Object.keys(payload.item).forEach(key => {
         Vue.set(


### PR DESCRIPTION
Client required that the notification banner for group/individual exams had the ability to re-direct the user to the exam-inventory page WITH preset inventory filters set. This PR has a button added to the rightmost corner of the notification banner, that when clicked, pushes the user to the exam route, and sets the exam filter mutation to specific values based upon which exam notification is present (group, individual or both).

The filters on the Exam Inventory have been consolidated to two dropdowns: one that contains exam types (ind, group all) and another that has present filter combinations. Extended filtering functionality was added to the filter function present on the table to account for BOTH individual and group exams that require attention, as there was no way to accurately display the combined set of both exam types that require attention.

All present functionality on the exam inventory page was tested after filtering was changed to ensure that new changes only affected the scope of this pull request.

Styling changes to the exam inventory table were also made during this commit:
	- expiry date text color is now red if todays date is past the expiry date
	- pagination has been moved from the bottom left corner of the table to the top right corner of the table