### PR TITLE
Phase 2 - Database Enhancements

### DIFF
--- a/api/app/models/bookings/exam_type.py
+++ b/api/app/models/bookings/exam_type.py
@@ -28,7 +28,11 @@ class ExamType(Base):
     group_exam_ind = db.Column(db.Integer,  nullable=False)
     pesticide_exam_ind = db.Column(db.Integer, nullable=False)
 
-    exam = db.relationship("Exam", lazy=False)
+    # TODO changed lazy=false to lazy=raise
+    exam = db.relationship("Exam", lazy='raise')
+
+    # TODO changed lazy4-false to no lazy option
+    #exam = db.relationship("Exam", lazy=False)
 
     def __repr__(self):
         return '<Exam Type Name: (name={self.exam_type_name!r})>'.format(self=self)

--- a/api/app/resources/bookings/exam/exam_put.py
+++ b/api/app/resources/bookings/exam/exam_put.py
@@ -36,6 +36,7 @@ class ExamPut(Resource):
         if not json_data:
             return {"message": "No input data received for updating an exam"}
 
+        # TODO Deleted date filter original
         exam = Exam.query.filter_by(exam_id=id).first_or_404()
 
         if not (exam.office_id == csr.office_id or csr.liaison_designate == 1):

--- a/api/app/schemas/bookings/booking_schema.py
+++ b/api/app/schemas/bookings/booking_schema.py
@@ -37,6 +37,7 @@ class BookingSchema(ma.ModelSchema):
     sbc_staff_invigilated = fields.Int()
     booking_contact_information = fields.Str()
 
-    invigilator = fields.Nested(InvigilatorSchema())
+    invigilator = fields.Nested(InvigilatorSchema(only=('invigilator_id', 'invigilator_name', 'invigilator_notes')))
     room = fields.Nested(RoomSchema(exclude=("booking", "office",)))
-    office = fields.Nested(OfficeSchema())
+    office = fields.Nested(OfficeSchema(only=('appointments_enabled_ind', 'exams_enabled_ind', 'office_id',
+                                              'office_name', 'office_number', 'timezone')))

--- a/api/app/schemas/bookings/exam_schema.py
+++ b/api/app/schemas/bookings/exam_schema.py
@@ -48,4 +48,6 @@ class ExamSchema(ma.ModelSchema):
 
     booking = fields.Nested(BookingSchema())
     exam_type = fields.Nested(ExamTypeSchema())
-    office = fields.Nested(OfficeSchema(exclude=("csrs",)))
+    office = fields.Nested(OfficeSchema(only=('appointments_enabled_ind', 'exams_enabled_ind', 'office_id',
+                                              'office_name', 'office_number', 'timezone')))
+


### PR DESCRIPTION
Since moving the queue application from a mysql backend to a postgres backend, the client has noticied far too many long running queries and timeouts on the backend. This prompted a review/audit of how and what the database is returning when API calls are made.

The first thing that was reviewed was the schema objects for exams and bookings. Here, only very specific rows were returned, cutting down the size of the JSON object returned in most cases by half, which in turn sped up query return times greatly. Next the lazy parameters on the exam <-> exam_type relationship was reviewed. First the lazy condition was removed, then altered to be 'raise'. This removed an outstanding long query response time from logs. Finally, a deleted_date filter was added to the exam_put end-point which helped reduce return time for this action as well.

All actions (Create, Read, Update and Delete) were reviewed during and after work was completed for any application functionality that touched the exam or booking end-points that use the models/schemas/end-points that were changed.