### PR TITLE
Phase 1 - Office Name Field Reset

### DIFF
--- a/frontend/src/exams/add-exam-modal.vue
+++ b/frontend/src/exams/add-exam-modal.vue
@@ -179,6 +179,7 @@
         'captureExamDetail',
         'resetCaptureForm',
         'resetAddExamModal',
+        'resetLogAnotherExamModal',
         'resetCaptureTab',
         'setAddExamModalSetting',
         'updateCaptureTab',
@@ -267,11 +268,14 @@
         }
       },
       logAnother() {
+        let { setup } = this.addExamModal
         this.resetModal()
         this.unSubmitted = true
         this.submitMsg = ''
         this.status = 'unknown'
         this.captureExamDetail({ key: 'exam_method', value: 'paper' })
+        this.resetLogAnotherExamModal(setup)
+
         this.initialize()
       },
       resetModal() {

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -2386,7 +2386,16 @@ export const store = new Vuex.Store({
         office_number: null,
       }
     },
-  
+
+    resetLogAnotherExamModal: (state, setup) => {
+      state.addExamModal = {
+        visible: true,
+        setup: setup,
+        step1MenuOpen: true,
+        office_number: null,
+      }
+    },
+
     toggleGenFinReport(state, payload) {
       state.showGenFinReportModal = payload
     },


### PR DESCRIPTION
Client found a small bug with previous phase 1 work, where if the user enters an exam via add exam modal, and clicks the "Log Another" button in the final step, the office name and number field is re-populated with the previous office name and number field.

Additional functionality had to be added to the logAnother function to reset the state object when the form is re-rendered to have a blank office_number field.