### PR TITLE
Update smartboard code

### DIFF
--- a/api/app/resources/theq/service_requests_list.py
+++ b/api/app/resources/theq/service_requests_list.py
@@ -45,6 +45,7 @@ class ServiceRequestsList(Resource):
             print("==> No service_request parameter in POST /service_requests/")
             print("    --> CSR:       " + csr.username)
             print("    --> json_data: " + json.dumps(json_data))
+            return {"message": "No input data received for creating service request"}, 400
 
         try:
             service_request = self.service_request_schema.load(json_data['service_request']).data
@@ -60,6 +61,7 @@ class ServiceRequestsList(Resource):
             print("==> service_request is None in POST /service_requests/, error in schema.load")
             print("    --> CSR:       " + csr.username)
             print("    --> json_data: " + json.dumps(json_data['service_request']))
+            return {"message": "Service request is none trying to create service request"}, 400
 
         active_sr_state = SRState.get_state_by_name("Active")
         complete_sr_state = SRState.get_state_by_name("Complete")
@@ -79,12 +81,17 @@ class ServiceRequestsList(Resource):
             print("==> An exception getting service info")
             print("    --> CSR:       " + csr.username)
             print("    --> json_data: " + json.dumps(json_data['service_request']))
+            return {"error": "Could not find service for service_id: " + str(service_request.service_id)}, 400
 
         if citizen is None:
             return {"message": "No matching citizen found for citizen_id"}, 400
 
         if service is None:
             return {"message": "No matching service found for service_id"}, 400
+
+        if service.parent_id is None:
+            print("==> CSR has selected a category, rather than a service.  This should not be possible")
+            return {"message": "CSR has selected a category, rather than a service. Should not be possible"}, 400
 
         # Find the currently active service_request and close it (if it exists)
         current_sr_number = 0

--- a/api/app/resources/theq/smartboard.py
+++ b/api/app/resources/theq/smartboard.py
@@ -46,17 +46,25 @@ class Smartboard(Resource):
             for c in citizens:
                 active_service_request = c.get_active_service_request()
 
-                # Filter Back Office out of services
-                if active_service_request.service.parent.service_name == "Back Office":
-                    continue
+                #  Make sure a category, rather than a service, hasn't slipped in somehow.
+                if active_service_request.service.parent:
 
-                active_period = active_service_request.get_active_period()
-                period = self.period_schema.dump(active_period)
+                  # Filter Back Office out of services
+                  if active_service_request.service.parent.service_name == "Back Office":
+                      continue
 
-                citizens_waiting.append({
-                    "ticket_number": c.ticket_number,
-                    "active_period": period.data
-                })
+                  active_period = active_service_request.get_active_period()
+                  period = self.period_schema.dump(active_period)
+
+                  citizens_waiting.append({
+                      "ticket_number": c.ticket_number,
+                      "active_period": period.data
+                  })
+
+                else:
+                    #  Display error to console, no other action taken.
+                    print("==> Error in Smartboard: Citizen has no active service request. " \
+                            + "Possible cause, category, not service, selected.")
 
             return {
                 "office_type": office.sb.sb_type,

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.0.49
+          v1.0.50
         </div>
       </div>
     </div>


### PR DESCRIPTION
Smartboard no longer crashes if CSR selects a category, rather than a service
- this only happened when category put in the Quick List.
- this should not be possible anymore
Quick Pick code updated so if a category makes it to the list, it is rejected when CSR selects it
When errors detected, error code returned, in addition to messages being printed.