### PR TITLE
Monthly Sessional Icon Bug

### DIFF
--- a/frontend/src/exams/exam-inventory-table.vue
+++ b/frontend/src/exams/exam-inventory-table.vue
@@ -1116,6 +1116,9 @@
           return lifeRing
         }
         if (item.exam_type.exam_type_name === 'Monthly Session Exam') {
+          if(item.number_of_students === null && length_of_invigilator_array > 0){
+            return exclamationTriangle
+          }
           if (!item.booking) {
             return lifeRing
           }


### PR DESCRIPTION
Client noted that if monthly sessional exams were created without students that the wrong icon appeared in the exam inventory table (life ring instead of exclamation). Likely functionality that was missed in requirements as this was not part of logic used in the row rendering of the table.

squash