### PR TITLE
Snowplow appointments, fixes to account for database creation

### DIFF
--- a/api/app/resources/bookings/appointment/appointment_delete.py
+++ b/api/app/resources/bookings/appointment/appointment_delete.py
@@ -18,7 +18,7 @@ from app.models.bookings import Appointment
 from app.schemas.bookings import AppointmentSchema
 from app.models.theq import CSR
 from qsystem import api, db, oidc
-
+from app.utilities.snowplow import SnowPlow
 
 @api.route("/appointments/<int:id>/", methods=["DELETE"])
 class AppointmentDelete(Resource):
@@ -34,6 +34,9 @@ class AppointmentDelete(Resource):
                                        .filter_by(office_id=csr.office_id)\
                                        .first_or_404()
 
+        SnowPlow.snowplow_appointment(None, csr, appointment, 'appointment_delete')
+
         db.session.delete(appointment)
         db.session.commit()
+
         return {}, 204

--- a/api/app/resources/bookings/appointment/appointment_delete.py
+++ b/api/app/resources/bookings/appointment/appointment_delete.py
@@ -28,8 +28,6 @@ class AppointmentDelete(Resource):
     @oidc.accept_token(require_token=True)
     def delete(self, id):
 
-        print("==> In the Python DELETE /appointments/<id>/ endpoint")
-
         csr = CSR.find_by_username(g.oidc_token_info['username'])
 
         appointment = Appointment.query.filter_by(appointment_id=id)\

--- a/api/app/resources/bookings/appointment/appointment_post.py
+++ b/api/app/resources/bookings/appointment/appointment_post.py
@@ -19,6 +19,7 @@ from app.schemas.bookings import AppointmentSchema
 from app.schemas.theq import CitizenSchema
 from app.models.theq import CSR, CitizenState
 from qsystem import api, api_call_with_retry, db, oidc
+from app.utilities.snowplow import SnowPlow
 from datetime import datetime
 
 @api.route("/appointments/", methods=["POST"])
@@ -59,6 +60,8 @@ class AppointmentPost(Resource):
             appointment.citizen_id = citizen.citizen_id
             db.session.add(appointment)
             db.session.commit()
+
+            SnowPlow.snowplow_appointment(citizen, csr, appointment, 'appointment_create')
 
             result = self.appointment_schema.dump(appointment)
 

--- a/api/app/resources/bookings/appointment/appointment_put.py
+++ b/api/app/resources/bookings/appointment/appointment_put.py
@@ -19,7 +19,7 @@ from qsystem import api, db, oidc
 from app.models.bookings import Appointment
 from app.models.theq import CSR
 from app.schemas.bookings import AppointmentSchema
-
+from app.utilities.snowplow import SnowPlow
 
 @api.route("/appointments/<int:id>/", methods=["PUT"])
 class AppointmentPut(Resource):
@@ -48,6 +48,12 @@ class AppointmentPut(Resource):
 
         db.session.add(appointment)
         db.session.commit()
+
+        #   Make Snowplow call.
+        schema = 'appointment_update'
+        if "checked_in_time" in json_data:
+            schema = 'appointment_checkin'
+        SnowPlow.snowplow_appointment(None, csr, appointment, schema)
 
         result = self.appointment_schema.dump(appointment)
 

--- a/api/app/resources/bookings/appointment/appointment_recurring_delete.py
+++ b/api/app/resources/bookings/appointment/appointment_recurring_delete.py
@@ -28,8 +28,6 @@ class AppointmentRecurringDelete(Resource):
     @oidc.accept_token(require_token=True)
     def delete(self, id):
 
-        print("==> In the Python DELETE /appointments/recurring/<id> endpoint")
-
         csr = CSR.find_by_username(g.oidc_token_info['username'])
 
         appointments = Appointment.query.filter_by(recurring_uuid=id)\

--- a/api/app/resources/theq/citizen/citizen_detail.py
+++ b/api/app/resources/theq/citizen/citizen_detail.py
@@ -73,5 +73,12 @@ class CitizenDetail(Resource):
         return {'citizen': result.data,
                 'errors': result.errors}, 200
 
-counter = Counter.query.filter(Counter.counter_name=="Counter")[0]
-counter_id = counter.counter_id
+try:
+    counter = Counter.query.filter(Counter.counter_name=="Counter")[0]
+    counter_id = counter.counter_id
+#  NOTE!!  There should ONLY be an exception when first building the database
+#          from a python3 manage.py db upgrade command.
+except:
+    counter_id = 1
+    print("==> In citizen_detail.py")
+    print("    --> NOTE!!  You should only see this if doing a 'python3 manage.py db upgrade'")

--- a/api/app/resources/theq/citizen/citizen_list.py
+++ b/api/app/resources/theq/citizen/citizen_list.py
@@ -77,5 +77,10 @@ class CitizenList(Resource):
         return {'citizen': result.data,
                 'errors': result.errors}, 201
 
-citizen_state = CitizenState.query.filter_by(cs_state_name="Active").first()
-active_id = citizen_state.cs_id
+try:
+    citizen_state = CitizenState.query.filter_by(cs_state_name="Active").first()
+    active_id = citizen_state.cs_id
+except:
+    active_id = 1
+    print("==> In citizen_list.py")
+    print("    --> NOTE!!  You should only see this if doing a 'python3 manage.py db upgrade'")

--- a/api/app/resources/theq/service_requests_list.py
+++ b/api/app/resources/theq/service_requests_list.py
@@ -189,5 +189,10 @@ class ServiceRequestsList(Resource):
         return {'service_request': result.data,
                 'errors': result.errors}, 201
 
-citizen_state = CitizenState.query.filter_by(cs_state_name="Active").first()
-active_id = citizen_state.cs_id
+try:
+    citizen_state = CitizenState.query.filter_by(cs_state_name="Active").first()
+    active_id = citizen_state.cs_id
+except:
+    active_id = 1
+    print("==> In service_requests_list.py")
+    print("    --> NOTE!!  You should only see this if doing a 'python3 manage.py db upgrade'")

--- a/api/app/utilities/snowplow.py
+++ b/api/app/utilities/snowplow.py
@@ -21,7 +21,6 @@ from app.models.theq.service import Service
 from app.models.theq.smartboard import SmartBoard
 from snowplow_tracker import Subject, Tracker, AsyncEmitter
 from snowplow_tracker import SelfDescribingJson
-import logging
 import os
 from qsystem import application, my_print
 from datetime import datetime, timezone
@@ -290,22 +289,7 @@ class SnowPlow():
         return appointment
 
     @staticmethod
-    def log_snowplow_call(jsondata):
-        if isinstance(jsondata, str):
-            module_logger.critical("------------------------------")
-        else:
-            sp_string = jsondata.to_string()
-            sp_array = sp_string.split("/")
-            sp_output = '{"schema": "' + sp_array[1] + '/' + sp_array[3]
-            module_logger.critical(sp_output)
-
-    @staticmethod
     def make_tracking_call(schema, citizen, office, agent):
-        SnowPlow.log_snowplow_call("")
-        SnowPlow.log_snowplow_call(schema)
-        SnowPlow.log_snowplow_call(citizen)
-        SnowPlow.log_snowplow_call(office)
-        SnowPlow.log_snowplow_call(agent)
         t.track_self_describing_event(schema, [citizen, office, agent])
 
 # Set up core Snowplow environment
@@ -313,21 +297,3 @@ if SnowPlow.call_snowplow_flag:
     s = Subject()  # .set_platform("app")
     e = AsyncEmitter(SnowPlow.sp_endpoint, on_failure=SnowPlow.failure, protocol="https")
     t = Tracker(e, encode_base64=False, app_id=SnowPlow.sp_appid, namespace=SnowPlow.sp_namespace)
-
-    #  Set up the correct level of logging.
-    print_flag = application.config['PRINT_ENABLE']
-    location = "logs/snowplow.log"
-    formatter = logging.Formatter('[%(asctime)s.] %(message)s')
-
-    #  Translate the logging level.
-    msg_level = logging.CRITICAL
-
-    #  All OK.  Set up logging options
-    log_file_handler = logging.FileHandler(location)
-    log_file_handler.setFormatter(formatter)
-    log_stream_handler = logging.StreamHandler()
-    log_stream_handler.setFormatter(formatter)
-    module_logger = logging.getLogger("slowplow-logger")
-    module_logger.setLevel(msg_level)
-    module_logger.addHandler(log_file_handler)
-    module_logger.addHandler(log_stream_handler)

--- a/api/app/utilities/snowplow.py
+++ b/api/app/utilities/snowplow.py
@@ -164,8 +164,14 @@ class SnowPlow():
     @staticmethod
     def get_csr(csr):
 
-        role_name = csr.role.role_code
+        #   Get the counter type.  Receptioninst is separate case.
+        if csr.receptionist_ind == 1:
+            counter_name = "Receptionist"
+        else:
+            counter_name = csr.counter.counter_name
 
+        #   Get the role of the agent, convert to correct case
+        role_name = csr.role.role_code
         #  Translate the role code from upper to mixed case.
         if (role_name == 'SUPPORT'):
             role_name = "Support"
@@ -178,7 +184,7 @@ class SnowPlow():
         agent = SelfDescribingJson('iglu:ca.bc.gov.cfmspoc/agent/jsonschema/3-0-0',
                                    {"agent_id": csr.csr_id,
                                     "role": role_name,
-                                    "counter_type": csr.counter.counter_name})
+                                    "counter_type": counter_name})
 
         return agent
 

--- a/api/app/utilities/snowplow.py
+++ b/api/app/utilities/snowplow.py
@@ -116,7 +116,7 @@ class SnowPlow():
             citizen_type = citizen_obj.counter.counter_name
 
         # Set up the citizen context.
-        citizen = SelfDescribingJson('iglu:ca.bc.gov.cfmspoc/citizen/jsonschema/3-0-0',
+        citizen = SelfDescribingJson('iglu:ca.bc.gov.cfmspoc/citizen/jsonschema/4-0-0',
                                       {"client_id": citizen_obj.citizen_id, "service_count": svc_number,
                                        "counter_type": citizen_type})
 
@@ -154,8 +154,9 @@ class SnowPlow():
         csr_qtxn = (csr.qt_xn_csr_ind == 1)
 
         #  Set up the CSR context.
-        agent = SelfDescribingJson('iglu:ca.bc.gov.cfmspoc/agent/jsonschema/2-0-1',
-                                   {"agent_id": csr.csr_id, "role": role_name, "quick_txn": csr_qtxn})
+        agent = SelfDescribingJson('iglu:ca.bc.gov.cfmspoc/agent/jsonschema/3-0-0',
+                                   {"agent_id": csr.csr_id, "role": csr.role.role_code,
+                                    "counter_type": csr.counter.counter_name})
 
         return agent
 

--- a/api/app/utilities/snowplow.py
+++ b/api/app/utilities/snowplow.py
@@ -40,7 +40,7 @@ class SnowPlow():
 
             # Set up contexts for the call.
             citizen_obj = Citizen.query.get(new_citizen.citizen_id)
-            citizen = SnowPlow.get_citizen(citizen_obj, True)
+            citizen = SnowPlow.get_citizen(citizen_obj, csr.counter.counter_name)
             office = SnowPlow.get_office(new_citizen.office_id)
             agent = SnowPlow.get_csr(csr)
 
@@ -59,7 +59,7 @@ class SnowPlow():
             # Set up the contexts for the call.
             citizen_obj = Citizen.query.get(service_request.citizen_id)
             current_sr_number = service_request.sr_number
-            citizen = SnowPlow.get_citizen(citizen_obj, False, svc_number = current_sr_number)
+            citizen = SnowPlow.get_citizen(citizen_obj, csr.counter.counter_name, svc_number = current_sr_number)
             office = SnowPlow.get_office(csr.office_id)
             agent = SnowPlow.get_csr(csr)
 
@@ -76,7 +76,7 @@ class SnowPlow():
 
             #  Set up the contexts for the call.
             citizen_obj = Citizen.query.get(citizen_id)
-            citizen = SnowPlow.get_citizen(citizen_obj, False, svc_number = current_sr_number)
+            citizen = SnowPlow.get_citizen(citizen_obj, csr.counter.counter_name, svc_number = current_sr_number)
             office = SnowPlow.get_office(csr.office_id)
             agent = SnowPlow.get_csr(csr)
 
@@ -109,18 +109,16 @@ class SnowPlow():
             print(event_dict)
 
     @staticmethod
-    def get_citizen(citizen_obj, add_flag, close_previous = False, svc_number = 1):
+    def get_citizen(citizen_obj, counter_name, svc_number = 1):
 
-        #  Set up citizen variables.
-        if add_flag:
-            citizen_qtxn = False
-        else:
-            citizen_qtxn = (citizen_obj.qt_xn_citizen_ind == 1)
+        citizen_type = counter_name
+        if citizen_obj.counter is not None:
+            citizen_type = citizen_obj.counter.counter_name
 
         # Set up the citizen context.
         citizen = SelfDescribingJson('iglu:ca.bc.gov.cfmspoc/citizen/jsonschema/3-0-0',
                                       {"client_id": citizen_obj.citizen_id, "service_count": svc_number,
-                                       "quick_txn": citizen_qtxn})
+                                       "counter_type": citizen_type})
 
         return citizen
 

--- a/api/app/utilities/snowplow.py
+++ b/api/app/utilities/snowplow.py
@@ -21,7 +21,9 @@ from app.models.theq.service import Service
 from app.models.theq.smartboard import SmartBoard
 from snowplow_tracker import Subject, Tracker, AsyncEmitter
 from snowplow_tracker import SelfDescribingJson
+import logging
 import os
+from qsystem import application, my_print
 
 class SnowPlow():
 
@@ -253,7 +255,20 @@ class SnowPlow():
         return appointment
 
     @staticmethod
+    def log_snowplow_call(jsondata):
+        sp_string=jsondata.to_string()
+        print(sp_string)
+        sp_schema = sp_string[0:sp_string.find(":")]
+        sp_array = sp_string.split("/")
+        sp_output = '{"schema": "' + sp_array[1] + '/' + sp_array[3]
+        module_logger.critical(sp_output)
+
+    @staticmethod
     def make_tracking_call(schema, citizen, office, agent):
+        SnowPlow.log_snowplow_call(schema)
+        SnowPlow.log_snowplow_call(citizen)
+        SnowPlow.log_snowplow_call(office)
+        SnowPlow.log_snowplow_call(agent)
         t.track_self_describing_event(schema, [citizen, office, agent])
 
 # Set up core Snowplow environment
@@ -261,3 +276,21 @@ if SnowPlow.call_snowplow_flag:
     s = Subject()  # .set_platform("app")
     e = AsyncEmitter(SnowPlow.sp_endpoint, on_failure=SnowPlow.failure, protocol="https")
     t = Tracker(e, encode_base64=False, app_id=SnowPlow.sp_appid, namespace=SnowPlow.sp_namespace)
+
+    #  Set up the correct level of logging.
+    print_flag = application.config['PRINT_ENABLE']
+    location = "logs/snowplow.log"
+    formatter = logging.Formatter('[%(asctime)s.] %(message)s')
+
+    #  Translate the logging level.
+    msg_level = logging.CRITICAL
+
+    #  All OK.  Set up logging options
+    log_file_handler = logging.FileHandler(location)
+    log_file_handler.setFormatter(formatter)
+    log_stream_handler = logging.StreamHandler()
+    log_stream_handler.setFormatter(formatter)
+    module_logger = logging.getLogger("slowplow-logger")
+    module_logger.setLevel(msg_level)
+    module_logger.addHandler(log_file_handler)
+    module_logger.addHandler(log_stream_handler)

--- a/api/config.py
+++ b/api/config.py
@@ -198,7 +198,7 @@ def configure_logging(app):
             module_logger = logging.getLogger(name)
             log_level = debug_string_to_debug_level(log_string)
             module_logger.setLevel(log_level)
-        if (basic_string != "DEFAULT"):
+        elif (basic_string != "DEFAULT"):
             print("        --> Logger " + name + " set to level LOG_BASIC level of " + basic_string)
             module_logger = logging.getLogger(name)
             module_logger.setLevel(basic_level)

--- a/frontend/src/appointments/appointments.vue
+++ b/frontend/src/appointments/appointments.vue
@@ -151,6 +151,8 @@
         if (event.id === '_tempEvent') {
           return
         }
+        console.log("==> In eventSelected")
+        console.log(event)
         this.clickedAppt = event
         this.highlightEvent(event)
         this.toggleCheckInModal(true)

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.0.64
+          v1.0.67
         </div>
       </div>
     </div>

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.0.68
+          v1.0.69
         </div>
       </div>
     </div>

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.0.67
+          v1.0.68
         </div>
       </div>
     </div>


### PR DESCRIPTION
Added snowplow calls for appointment_create, appointment_update, appointment_checkin
Upgrade schema for citizen (change qtxn integer to counter type string)
Upgrade schema for csr (change qtxn integer to counter type string)
Assign default values to database lookup values if no databases created yet
- as in the case of python3 manage.py db upgrade to create a database