### PR TITLE
Don't allow double clicking on the new quick serve, quick queue icons

### DIFF
--- a/frontend/src/add-citizen/form-components/tables.vue
+++ b/frontend/src/add-citizen/form-components/tables.vue
@@ -32,14 +32,14 @@
                    class="add_citizen_categories_table">
             <template slot="queueBut" slot-scope="data"
                       v-if="showQuickQIcon">
-              <div @click="sendToQueue(data.item)">
+              <div @click.once="sendToQueue(data.item)">
                 &nbsp;&nbsp;&nbsp;
                 <font-awesome-icon icon="share-square"
                                    style="fontSize: 1rem; color: blue;"/>
               </div>
             </template>
             <template slot="serveBut" slot-scope="data">
-              <div @click="serveCustomer(data.item)">
+              <div @click.once="serveCustomer(data.item)">
                 &nbsp;&nbsp;&nbsp;
                 <font-awesome-icon icon="hands-helping"
                                    style="fontSize: 1rem; color: green;"/>

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.0.75
+          v1.0.76
         </div>
       </div>
     </div>


### PR DESCRIPTION
Double clicking on these buttons, which causes grief, has been disabled.