### PR TITLE
Fix pressing both icons, one after the other

### DIFF
--- a/frontend/src/add-citizen/form-components/tables.vue
+++ b/frontend/src/add-citizen/form-components/tables.vue
@@ -84,7 +84,8 @@
         addModalSetup: 'addModalSetup',
         addCitizenModal: 'addCitizenModal',
         serviceModalForm: 'serviceModalForm',
-        addModalForm: 'addModalForm'
+        addModalForm: 'addModalForm',
+        performingAction: 'performingAction'
       }),
       ...mapGetters({
         form_data: 'form_data',
@@ -151,7 +152,7 @@
     },
 
     methods: {
-      ...mapMutations(['setAddModalSelectedItem', 'toggleExamsTrackingIP']),
+      ...mapMutations(['setAddModalSelectedItem', 'toggleExamsTrackingIP', 'setPerformingAction']),
       ...mapActions(['clickQuickServe', 'clickAddServiceApply',
         'clickBeginService', 'resetAddCitizenModal', 'clickAddToQueue',
         'clickEditApply']),
@@ -161,42 +162,41 @@
         this.setAddModalSelectedItem(item.service_name)
         this.$store.commit('updateAddModalForm', {type:'service',value:id})
       },
+
       sendToQueue(service) {
         this.setAddModalSelectedItem(service.service_name)
         this.$store.commit('updateAddModalForm', {type: 'service', value: service.service_id})
         this.clickAddToQueue()
       },
       serveCustomer(service) {
-        this.setAddModalSelectedItem(service.service_name)
-        this.$store.commit('updateAddModalForm', {type: 'service', value: service.service_id})
-        if (this.$route.path == "/exams") {
-          this.toggleExamsTrackingIP(true)
-          this.clickBeginService({simple: true})
-        }
-        else if (this.$route.path == "/appointments") {
-          this.$store.commit('appointmentsModule/setSelectedService', this.addModalForm.service)
-          this.closeAddServiceModal()
-        }
-        else if (this.$route.path == "/booking") {
-          this.toggleExamsTrackingIP(true)
-          this.clickBeginService({simple: true})
-        }
-        else if ((!this.simplifiedTicketStarted) && (this.addModalSetup == "reception" || this.addModalSetup == "non_reception")) {
-          this.clickBeginService({simple: false})
-        }
-        else if (this.simplifiedTicketStarted) {
-          if (this.addModalSetup == "add_mode") {
-            this.clickAddServiceApply()
-          }
-          else if (this.addModalSetup == "edit_mode") {
-            this.clickEditApply()
-          }
-          else {
-            console.log("==> No service selected.")
+        if (this.performingAction == false) {
+          this.setAddModalSelectedItem(service.service_name)
+          this.$store.commit('updateAddModalForm', {type: 'service', value: service.service_id})
+          if (this.$route.path == "/exams") {
+            this.toggleExamsTrackingIP(true)
+            this.clickBeginService({simple: true})
+          } else if (this.$route.path == "/appointments") {
+            this.$store.commit('appointmentsModule/setSelectedService', this.addModalForm.service)
+            this.closeAddServiceModal()
+          } else if (this.$route.path == "/booking") {
+            this.toggleExamsTrackingIP(true)
+            this.clickBeginService({simple: true})
+          } else if ((!this.simplifiedTicketStarted) && (this.addModalSetup == "reception" || this.addModalSetup == "non_reception")) {
+            this.clickBeginService({simple: false})
+          } else if (this.simplifiedTicketStarted) {
+            if (this.addModalSetup == "add_mode") {
+              this.clickAddServiceApply()
+            } else if (this.addModalSetup == "edit_mode") {
+              this.clickEditApply()
+            } else {
+              console.log("==> No service selected.")
+            }
+          } else {
+            console.log("==> Still no service selected")
           }
         }
         else {
-          console.log("==> Still no service selected")
+          console.log("==> Cannot quick serve customer, they are being added to the queue.")
         }
       },
       closeAddServiceModal() {

--- a/frontend/src/add-citizen/form-components/tables.vue
+++ b/frontend/src/add-citizen/form-components/tables.vue
@@ -164,9 +164,14 @@
       },
 
       sendToQueue(service) {
-        this.setAddModalSelectedItem(service.service_name)
-        this.$store.commit('updateAddModalForm', {type: 'service', value: service.service_id})
-        this.clickAddToQueue()
+        if (this.performingAction == false) {
+          this.setAddModalSelectedItem(service.service_name)
+          this.$store.commit('updateAddModalForm', {type: 'service', value: service.service_id})
+          this.clickAddToQueue()
+        }
+        else {
+          console.log("==> Cannot send to queue, citizen is being quick served")
+        }
       },
       serveCustomer(service) {
         if (this.performingAction == false) {

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.0.76
+          v1.0.77
         </div>
       </div>
     </div>


### PR DESCRIPTION
If the system was slow, or the user fast, the quick serve and quick add to queue icons could both be pressed, one after the other.