### PR TITLE
Substitute inline code for decorator code for two calls causing grief

### DIFF
--- a/api/app/resources/bookings/appointment/appointment_post.py
+++ b/api/app/resources/bookings/appointment/appointment_post.py
@@ -43,6 +43,7 @@ class AppointmentPost(Resource):
     @api_call_with_retry
     @has_any_role(roles=[Role.internal_user.value, Role.online_appointment_user.value])
     def post(self):
+        print("==> In AppointmentPost, POST /appointments/")
         json_data = request.get_json()
         if not json_data:
             return {"message": "No input data received for creating an appointment"}, 400

--- a/api/app/resources/theq/csr_states.py
+++ b/api/app/resources/theq/csr_states.py
@@ -18,7 +18,7 @@ from qsystem import api, db, oidc, time_print, get_key
 from sqlalchemy import exc
 from app.models.theq import CSRState
 from app.schemas.theq import CSRStateSchema
-from app.utilities.auth_util import Role, has_any_role
+from app.utilities.auth_util import Role, has_any_role, has_role
 
 
 @api.route("/csr_states/", methods=["GET"])
@@ -27,14 +27,11 @@ class CsrStateList(Resource):
     csr_state_schema = CSRStateSchema(many=True, exclude=('csrs'))
 
     @oidc.accept_token(require_token=True)
-    @has_any_role(roles=[Role.internal_user.value])
     def get(self):
         try:
             user = g.oidc_token_info['username']
-            key = get_key()
-            time_print("==> K<" + key + "> In CsrStateList, before call, user: " + user)
+            has_role([Role.internal_user.value], g.oidc_token_info['realm_access']['roles'], user, "CsrStateList GET /csr_states/")
             states = CSRState.query.all()
-            time_print("--> K<" + key + "> In CsrStateList, after  call, user: " + user)
             result = self.csr_state_schema.dump(states)
 
             return {'csr_states': result.data,

--- a/api/app/utilities/auth_util.py
+++ b/api/app/utilities/auth_util.py
@@ -43,15 +43,19 @@ def has_any_role(roles: list):
     def decorated(f):
         @wraps(f)
         def wrapper(*args, **kwargs):
-            user = g.oidc_token_info['username']
             token_roles = g.oidc_token_info['realm_access']['roles']
-            time_print("==> has_any_role, R: " + str(roles) + "; T: " + str(token_roles))
-            time_print("    --> U: " + user + "; C:  " + str(f))
             if any(role in token_roles for role in roles):
-                time_print(f'    --> KW: {kwargs}')
                 return f(*args, **kwargs)
             abort(403)
 
         return wrapper
 
     return decorated
+
+def has_role(need_roles: list, all_roles: list, user, caller):
+    if any(role in all_roles for role in need_roles):
+        return
+    else:
+        time_print("==> has_role, R: " + str(need_roles) + "; T: " + str(all_roles))
+        time_print("    --> U: " + user + "; C:  " + caller)
+        abort(403)

--- a/api/app/utilities/auth_util.py
+++ b/api/app/utilities/auth_util.py
@@ -43,9 +43,10 @@ def has_any_role(roles: list):
     def decorated(f):
         @wraps(f)
         def wrapper(*args, **kwargs):
+            user = g.oidc_token_info['username']
             token_roles = g.oidc_token_info['realm_access']['roles']
             time_print("==> has_any_role, R: " + str(roles) + "; T: " + str(token_roles))
-            time_print("    --> C:  " + str(f))
+            time_print("    --> U: " + user + "; C:  " + str(f))
             if any(role in token_roles for role in roles):
                 time_print(f'    --> KW: {kwargs}')
                 return f(*args, **kwargs)

--- a/api/config.py
+++ b/api/config.py
@@ -28,6 +28,7 @@ class BaseConfig(object):
     LOGGING_LEVEL = DEBUG
     LOGGING_FORMAT = '[%(asctime)s] %(levelname)-8s (%(name)s) <%(module)s.py>.%(funcName)s: %(message)s'
     PRINT_ENABLE = (os.getenv("PRINT_ENABLE","FALSE")).upper() == "TRUE"
+    PRINT_ENABLE_DEBUG_TYPEERROR = (os.getenv("PRINT_ENABLE_DEBUG_TYPEERROR","FALSE")).upper() == "TRUE"
     SOCKET_STRING = os.getenv('LOG_SOCKETIO', 'WARNING')
     ENGINE_STRING = os.getenv('LOG_ENGINEIO', 'WARNING')
 

--- a/api/qsystem.py
+++ b/api/qsystem.py
@@ -27,7 +27,8 @@ def my_print(string):
         print(time_string() + string)
 
 def time_print(string):
-    print(time_string() + string)
+    if debug_type_error_flag:
+        print(time_string() + string)
 
 def time_string():
     now = datetime.datetime.now()
@@ -43,6 +44,7 @@ application.url_map.strict_slashes = True
 #   Do basic application configuration
 configure_app(application)
 print_flag = application.config['PRINT_ENABLE']
+debug_type_error_flag = application.config['PRINT_ENABLE_DEBUG_TYPEERROR']
 socket_flag = application.config['SOCKET_FLAG']
 engine_flag = application.config['ENGINE_FLAG']
 

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.0.96
+          v1.0.97
         </div>
       </div>
     </div>


### PR DESCRIPTION
- citizen_list.py and csr_states.py now have inline authorization checks, not decorators
- removed excessive debugging statements
- added an environment flag, PRINT_ENABLE_DEBUG_TYPEERROR, to turn on and off debugging