### PR TITLE
Fix initial state of the appointments module so services display

### DIFF
--- a/appointment-frontend/src/components/appointment/ServiceSelection.vue
+++ b/appointment-frontend/src/components/appointment/ServiceSelection.vue
@@ -160,7 +160,7 @@ export default class ServiceSelection extends Mixins(StepperMixin) {
   private textCharsPrefix = 'Additional info you would like to add? (Optional - '
   private textCharsLeft = this.textCharsPrefix + this.charsLeft + ' chars left)'
   private textStyle = 'color:black !important;'
-  private keyPressed = false
+  private keyPressed = true
 
   private otherBookingOptionModel = false
 

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.1.02
+          v1.1.03
         </div>
       </div>
     </div>


### PR DESCRIPTION
Set initial state to be "no service selected", by setting keypress to be true
- indicates current data is invalid.  All data invalid after any key pressed in the service combobox