### PR TITLE
Correct SESSION_DATE_TIME field, Pesticide exams

### DIFF
--- a/api/app/utilities/bcmp_service.py
+++ b/api/app/utilities/bcmp_service.py
@@ -95,7 +95,6 @@ class BCMPService:
 
         bcmp_exam = {
             "EXAM_SESSION_LOCATION" : office_name,
-            "SESSION_DATE_TIME" : self.__exam_time_format(exam.expiry_date),
             "REGISTRAR_name" : oidc_token_info['preferred_username'],
             "RECIPIENT_EMAIL_ADDRESS" : oidc_token_info['email'],
             "REGISTRAR_phoneNumber" : "",
@@ -131,7 +130,7 @@ class BCMPService:
         
         bcmp_exam = {
             "EXAM_SESSION_LOCATION": office_name,
-            "SESSION_DATE_TIME" : self.__exam_time_format(exam.expiry_date),
+            "SESSION_DATE_TIME" : self.__exam_time_format(exam.booking.start_time),
             "REGISTRAR_name" : oidc_token_info['preferred_username'],
             "RECIPIENT_EMAIL_ADDRESS" : oidc_token_info['email'],
             "REGISTRAR_phoneNumber": "",

--- a/frontend/src/layout/footer.vue
+++ b/frontend/src/layout/footer.vue
@@ -24,7 +24,7 @@
           <a href="#" @click="keycloakLogin()" id="keycloak-login">Keycloak Login</a>
         </div>
         <div class="footer-anchor-item-last" style="display:inline-block; color: white; margin-right:15px;">
-          v1.1.17
+          v1.1.18
         </div>
       </div>
     </div>

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -2137,6 +2137,7 @@ export const store = new Vuex.Store({
       }
 
       let booking = makeBookingReqObj(context, responses)
+      postData.booking = booking
 
       let apiUrl = (isRequestExamReq) ? '/exams/bcmp/' : '/exams/'
 


### PR DESCRIPTION
Fixed code so that individual pesticide exams leave out the SESSION_DATE_TIME field
Group pesticide exams use the booking start_time field, rather than the expiry_date for the SESSION_DATE_TIME field.