### PR TITLE
Fix agenda view and socketio ping environment vars

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -157,6 +157,9 @@ class BaseConfig(object):
     else:
         SQLALCHEMY_ECHO=False
 
+    SOCKETIO_PING_TIMEOUT = int(os.getenv('SOCKETIO_PING_TIMEOUT', 5))
+    SOCKETIO_PING_INTERVAL = int(os.getenv('SOCKETIO_PING_INTERVAL', 25))
+    
     THEQ_FEEDBACK = (os.getenv('THEQ_FEEDBACK','')).upper().replace(" ","").split(",")
     SLACK_URL = os.getenv('SLACK_URL', '')
     ROCKET_CHAT_URL = os.getenv('ROCKET_CHAT_URL')

--- a/api/qsystem.py
+++ b/api/qsystem.py
@@ -60,6 +60,11 @@ appt_limit = application.config['APPOINTMENT_LIMIT_DAYS']
 db = SQLAlchemy(application)
 db.init_app(application)
 query_limit = application.config['DB_LONG_RUNNING_QUERY']
+ping_timeout_seconds = application.config['SOCKETIO_PING_TIMEOUT']
+ping_interval_seconds = application.config['SOCKETIO_PING_INTERVAL']
+print("==> socketIO Engine options")
+print("    --> ping_timeout_seconds:    " + str(ping_timeout_seconds))
+print("    --> ping_interval_seconds:   " + str(ping_interval_seconds))
 
 cache = Cache(config={'CACHE_TYPE': 'simple', 'CACHE_DEFAULT_TIMEOUT': application.config['CACHE_DEFAULT_TIMEOUT']})
 cache.init_app(application)
@@ -67,7 +72,7 @@ cache.init_app(application)
 ma = Marshmallow(application)
 
 #   Set up socket io and rabbit mq.
-socketio = SocketIO(logger=socket_flag, engineio_logger=engine_flag,ping_timeout=6,ping_interval=3,
+socketio = SocketIO(logger=socket_flag, engineio_logger=engine_flag,ping_timeout=ping_timeout_seconds,ping_interval=ping_interval_seconds,
                     cors_allowed_origins=application.config['CORS_ALLOWED_ORIGINS'])
 
 if application.config['ACTIVE_MQ_URL'] is not None:

--- a/frontend/src/components/Layout/footer.vue
+++ b/frontend/src/components/Layout/footer.vue
@@ -48,7 +48,7 @@
           class="footer-anchor-item-last"
           style="display: inline-block; color: white; margin-right: 15px"
         >
-          v2.1.4
+          v2.1.5
         </div>
       </div>
     </div>

--- a/frontend/src/components/agenda-screen/agenda-screen.vue
+++ b/frontend/src/components/agenda-screen/agenda-screen.vue
@@ -184,9 +184,8 @@ export default class AgendaScreen extends Vue {
       return false;
     })
 
-    
     if (this.$store.state.services.length === 0) {
-      //INC0074865 - Services not loaded on initial entry - call appointments to fetch services when serviceList lenght is 0
+      //  INC0074865 - Services not loaded on initial entry - call appointments to fetch services when serviceList length is 0
       this.getAppointments()  
     }
     // Format object for agenda table.

--- a/frontend/src/components/agenda-screen/agenda-screen.vue
+++ b/frontend/src/components/agenda-screen/agenda-screen.vue
@@ -184,6 +184,11 @@ export default class AgendaScreen extends Vue {
       return false;
     })
 
+    
+    if (this.$store.state.services.length === 0) {
+      //INC0074865 - Services not loaded on initial entry - call appointments to fetch services when serviceList lenght is 0
+      this.getAppointments()  
+    }
     // Format object for agenda table.
     return filteredDates.map(appt => {
       const service = this.$store.state.services


### PR DESCRIPTION
fixed bug related to INC0074865
In The Q Agenda view the service does not display when initially opened. 
Once appointments page is displayed the service will display on Agenda View.

Also added two enironment variables. 
If we bump up values we may be able to resolve Cannot connect to SID pod error
SOCKETIO_PING_TIMEOUT     (6 = Current value in Prod)
SOCKETIO_PING_INTERVAL = (3 = Current value in Prod)