### PR TITLE
fix Add & Edit services from Room Bookings, Service Flow screens 

### DIFF
--- a/frontend/src/components/AddCitizen/form-components/tables.vue
+++ b/frontend/src/components/AddCitizen/form-components/tables.vue
@@ -231,31 +231,27 @@ export default class Tables extends Vue {
 
   serveCustomerAction () {
     //  NOTE!!     When actionToTake is serveCustomer then we execute this code
-    if (this.$route.path == '/exams') {
+    if (this.addModalSetup === 'add_mode') {
+      this.clickAddServiceApply()
+    } else if (this.addModalSetup === 'edit_mode') {
+      this.clickEditApply()
+    } else if (this.$route.path === '/exams') {
       this.toggleExamsTrackingIP(true)
       this.clickBeginService({ simple: true })
-    } else if (this.$route.path == '/appointments') {
+    } else if (this.$route.path === '/appointments') {
       this.$store.commit('appointmentsModule/setSelectedService', this.addModalForm.service)
       this.closeAddServiceModal()
-    } else if (this.$route.path == '/booking') {
+    } else if (this.$route.path === '/booking') {
       this.toggleExamsTrackingIP(true)
       this.clickBeginService({ simple: true })
-    } else if (this.$route.path == '/service-flow') {
+    } else if (this.$route.path === '/service-flow') {
       // remove continue button in service flow
       this.toggleExamsTrackingIP(true)
       this.clickBeginService({ simple: true })
     } else if ((!this.simplifiedTicketStarted) && (this.addModalSetup == 'reception' || this.addModalSetup == 'non_reception')) {
       this.clickBeginService({ simple: false })
-    } else if (this.simplifiedTicketStarted) {
-      if (this.addModalSetup == 'add_mode') {
-        this.clickAddServiceApply()
-      } else if (this.addModalSetup == 'edit_mode') {
-        this.clickEditApply()
-      } else {
-        console.log('==> No service selected.')
-      }
     } else {
-      console.log('==> Still no service selected')
+      console.log('==> No service selected.')
     }
   }
 

--- a/frontend/src/store/actions/actions-model.ts
+++ b/frontend/src/store/actions/actions-model.ts
@@ -1354,10 +1354,10 @@ export const commonActions: any = {
     context.commit('setPerformingAction', true)
 
     context
-      .dispatch('putCitizen')
+      .dispatch('putServiceRequest')
       .then(() => {
         context
-          .dispatch('putServiceRequest')
+          .dispatch('putCitizen')
           .then(() => {
             context
               .dispatch('postHold', citizen_id)
@@ -1488,10 +1488,10 @@ export const commonActions: any = {
     context.commit('setPerformingAction', true)
 
     context
-      .dispatch('putCitizen')
+      .dispatch('putServiceRequest')
       .then(() => {
         context
-          .dispatch('putServiceRequest')
+          .dispatch('putCitizen')
           .then(() => {
             context
               .dispatch('postAddToQueue', citizen_id)
@@ -2380,7 +2380,7 @@ export const commonActions: any = {
         resolve(' ')
       })
     }
-
+    
     return new Promise((resolve, reject) => {
       const url = `/service_requests/${sr_id}/`
       Axios(context)

--- a/frontend/src/store/mutations/mutations-model.ts
+++ b/frontend/src/store/mutations/mutations-model.ts
@@ -128,11 +128,19 @@ export const commonMutation: any = {
     (state.editDeleteSeries = payload),
 
   setServiceModalForm (state, citizen) {
+    
     const citizen_comments = citizen.citizen_comments
     const activeService = citizen.service_reqs.filter(sr =>
       sr.periods.some(p => p.time_end === null)
     )
-    const activeQuantity = activeService[0].quantity
+    let activeQuantity = activeService[0].quantity
+    // INC0086005 - On initial entry to the Service Modal use activeService Quantity, 
+    // when placing on Hold/The Q pick up value from modal
+    if (!state.serviceModalForm.citizen_id) {
+      activeQuantity = activeService[0].quantity
+    } else {
+      activeQuantity = state.serviceModalForm.activeQuantity
+    }
     const { citizen_id } = citizen
     const service_citizen = citizen
     const priority = citizen.priority

--- a/frontend/src/store/mutations/mutations-model.ts
+++ b/frontend/src/store/mutations/mutations-model.ts
@@ -128,19 +128,11 @@ export const commonMutation: any = {
     (state.editDeleteSeries = payload),
 
   setServiceModalForm (state, citizen) {
-    
     const citizen_comments = citizen.citizen_comments
     const activeService = citizen.service_reqs.filter(sr =>
       sr.periods.some(p => p.time_end === null)
     )
-    let activeQuantity = activeService[0].quantity
-    // INC0086005 - On initial entry to the Service Modal use activeService Quantity, 
-    // when placing on Hold/The Q pick up value from modal
-    if (!state.serviceModalForm.citizen_id) {
-      activeQuantity = activeService[0].quantity
-    } else {
-      activeQuantity = state.serviceModalForm.activeQuantity
-    }
+    const activeQuantity = activeService[0].quantity
     const { citizen_id } = citizen
     const service_citizen = citizen
     const priority = citizen.priority


### PR DESCRIPTION
I have two fixes on this P.R.

INC0086548 - Edit Service Issue - Fix "services" edit button from hanging
INC0086994 - The Q Service Timer  - Bug that afftects ServiceFlow -- smaller services modal when starting room booking and /or serviceflow, unable to add another service properly