### PR TITLE
remove add_mode from appointment module

### DIFF
--- a/frontend/src/store/modules/appointments-module.ts
+++ b/frontend/src/store/modules/appointments-module.ts
@@ -392,9 +392,6 @@ export default {
 
     toggleAddModal ({ commit }, payload) {
       commit('toggleAddModal', payload, { root: true })
-      if (payload) {
-        commit('switchAddModalMode', 'add_mode', { root: true })
-      }
     },
 
     // toggleApptBookingModalWithDraft ({ commit }, payload) {


### PR DESCRIPTION
1) when adding service to an appointment (do not use add_mode)  that is reserved for Add Next Service.