### PR TITLE
Edit Group Exam Modal - display date and time

### DIFF
--- a/frontend/src/components/exams/edit-group-exam-modal.vue
+++ b/frontend/src/components/exams/edit-group-exam-modal.vue
@@ -852,28 +852,19 @@ export default class EditGroupExamBookingModal extends Vue {
   }
 
   get fieldDisabled () {
-    console.log('fieldDisabled ==> this.role_code', this.role_code)
-    console.log('fieldDisabled ==> this.examType', this.examType)
-    console.log('fieldDisabled ==> this.is_ita2_designate', this.is_ita2_designate)
-    console.log('fieldDisabled ==> this.is_pesticide_designate', this.is_pesticide_designate)
-    console.log('fieldDisabled ==> this.is_office_manager', this.is_office_manager)
-   
     if (this.role_code === 'SUPPORT') {
       return false
     }
     if (this.examType === 'challenger') {
       if (this.role_code !== 'GA' && !this.is_ita2_designate && !this.is_office_manager) {
-        console.log('RETURN True BECAUSE YOU ARE NOT A GA or ITA LIASON or OFFICE MANAGER')
         return true
       }
     }
     if (this.examType === 'group') {
       if (!this.is_ita2_designate && !this.is_pesticide_designate) {
-        console.log('RETURN TRUE BECAUSE YOU ARE NOT AN ITA LIASON OR PESTICIDE LIASON')
         return true
       }
     }
-    console.log('RETURN FALSE BY DEFAULT')
     return false
   }
 

--- a/frontend/src/components/exams/edit-group-exam-modal.vue
+++ b/frontend/src/components/exams/edit-group-exam-modal.vue
@@ -726,8 +726,9 @@ export default class EditGroupExamBookingModal extends Vue {
   @Getter('role_code') private role_code!: any;
   @Getter('invigilator_dropdown') private invigilator_dropdown!: any;
   @Getter('is_ita2_designate') private is_ita2_designate!: any;
+  @Getter('is_pesticide_designate') private is_pesticide_designate!: any;
+  @Getter('is_office_manager') private is_office_manager!: any;
   @Getter('invigilator_multi_select') private invigilator_multi_select!: any;
-  // @Getter('is_ita2_designate') private is_ita2_designate!: any;
   @Getter('shadow_invigilator_options') private shadow_invigilator_options!: any;
   @Getter('shadow_invigilators') private shadow_invigilators!: any;
 
@@ -851,9 +852,28 @@ export default class EditGroupExamBookingModal extends Vue {
   }
 
   get fieldDisabled () {
-    if ((this.role_code !== 'GA' && !this.is_ita2_designate) && this.examType != 'other') {
-      return true
+    console.log('fieldDisabled ==> this.role_code', this.role_code)
+    console.log('fieldDisabled ==> this.examType', this.examType)
+    console.log('fieldDisabled ==> this.is_ita2_designate', this.is_ita2_designate)
+    console.log('fieldDisabled ==> this.is_pesticide_designate', this.is_pesticide_designate)
+    console.log('fieldDisabled ==> this.is_office_manager', this.is_office_manager)
+   
+    if (this.role_code === 'SUPPORT') {
+      return false
     }
+    if (this.examType === 'challenger') {
+      if (this.role_code !== 'GA' && !this.is_ita2_designate && !this.is_office_manager) {
+        console.log('RETURN True BECAUSE YOU ARE NOT A GA or ITA LIASON or OFFICE MANAGER')
+        return true
+      }
+    }
+    if (this.examType === 'group') {
+      if (!this.is_ita2_designate && !this.is_pesticide_designate) {
+        console.log('RETURN TRUE BECAUSE YOU ARE NOT AN ITA LIASON OR PESTICIDE LIASON')
+        return true
+      }
+    }
+    console.log('RETURN FALSE BY DEFAULT')
     return false
   }
 

--- a/frontend/src/components/exams/edit-group-exam-modal.vue
+++ b/frontend/src/components/exams/edit-group-exam-modal.vue
@@ -39,6 +39,14 @@
                   <div>Writers:</div>
                   <div>{{ actionedExam.number_of_students }}</div>
                 </div>
+                <div class="q-id-grid-col">
+                  <div>Exam Date:</div>
+                  <div>{{ originalDate }}</div>
+                </div>
+                <div class="q-id-grid-col">
+                  <div>Exam Time:</div>
+                  <div>{{ originalTime }}</div>
+                </div>
               </div>
             </div>
           </b-col>
@@ -801,6 +809,19 @@ export default class EditGroupExamBookingModal extends Vue {
       default:
         return 'Other'
     }
+  }
+
+  get originalDate () {
+    const { start_time } = this.actionedExam.booking
+    const { timezone_name } = this.actionedExam.booking.office.timezone
+    return zone.tz(start_time, timezone_name).clone().format('YYYY-MM-DD').toString()
+  }
+
+  get originalTime () {
+    const { start_time } = this.actionedExam.booking
+    const { timezone_name } = this.actionedExam.booking.office.timezone
+    const time = zone.tz(start_time, timezone_name).clone().format('YYYY-MM-DD[T]HH:mm:ss').toString()
+    return moment(time).format('HH:mm').toString()
   }
 
   get editedTimezone () {

--- a/frontend/src/components/exams/edit-group-exam-modal.vue
+++ b/frontend/src/components/exams/edit-group-exam-modal.vue
@@ -39,14 +39,6 @@
                   <div>Writers:</div>
                   <div>{{ actionedExam.number_of_students }}</div>
                 </div>
-                <div class="q-id-grid-col">
-                  <div>Exam Date:</div>
-                  <div>{{ originalDate }}</div>
-                </div>
-                <div class="q-id-grid-col">
-                  <div>Exam Time:</div>
-                  <div>{{ originalTime }}</div>
-                </div>
               </div>
             </div>
           </b-col>
@@ -72,7 +64,7 @@
             <b-form-group>
               <label>Exam Date</label><br />
               <DatePicker
-                :value="date"
+                v-model="date"
                 style="color: black"
                 :disabled="fieldDisabled"
                 name="date"
@@ -80,6 +72,7 @@
                 class="w-100 date-time-fields"
                 @input="checkDate"
                 lang="en"
+                type="date"
               >
               </DatePicker>
             </b-form-group>
@@ -748,8 +741,8 @@ export default class EditGroupExamBookingModal extends Vue {
   @Mutation('toggleEditGroupBookingModal') public toggleEditGroupBookingModal: any
 
   public invigilator_id: any = ''
-  public date: any = ''
-  public time: any = ''
+  public date: any = null
+  public time: any = null
   public offsite_location: any = ''
   public notes: any = ''
   public eventId: any = ''
@@ -809,19 +802,6 @@ export default class EditGroupExamBookingModal extends Vue {
       default:
         return 'Other'
     }
-  }
-
-  get originalDate () {
-    const { start_time } = this.actionedExam.booking
-    const { timezone_name } = this.actionedExam.booking.office.timezone
-    return zone.tz(start_time, timezone_name).clone().format('YYYY-MM-DD').toString()
-  }
-
-  get originalTime () {
-    const { start_time } = this.actionedExam.booking
-    const { timezone_name } = this.actionedExam.booking.office.timezone
-    const time = zone.tz(start_time, timezone_name).clone().format('YYYY-MM-DD[T]HH:mm:ss').toString()
-    return moment(time).format('HH:mm').toString()
   }
 
   get editedTimezone () {
@@ -913,11 +893,7 @@ export default class EditGroupExamBookingModal extends Vue {
     // JSTOTS INFO removed new from moment. no need to use new with moment
     const date = moment(this.itemCopy.booking.start_time)
     // JSTOTS INFO removed new from moment. no need to use new with moment
-    const event = moment(e)
-    if (event.isBefore(moment(), 'day')) {
-      return
-    }
-    this.date = event
+    this.date = new Date(e)
     this.showMessage = false
     if (!this.itemCopy.booking) {
       if (!this.editedFields.includes('date')) {
@@ -1286,8 +1262,9 @@ export default class EditGroupExamBookingModal extends Vue {
       const { start_time } = tempItem.booking
       const { timezone_name } = this.actionedExam.booking.office.timezone
       const time = zone.tz(start_time, timezone_name).clone().format('YYYY-MM-DD[T]HH:mm:ss').toString()
-      this.time = moment(time).format('YYYY-MM-DD[T]HH:mm:ssZ').toString()
-      this.date = zone.tz(start_time, timezone_name).clone().format('YYYY-MM-DD[T]HH:mm:ssZ').toString()
+      this.time = new Date(time)
+      const date = zone.tz(start_time, timezone_name).clone().format('YYYY-MM-DD[T]HH:mm:ssZ').toString()
+      this.date = new Date(date)
       if (tempItem.booking.sbc_staff_invigilated) {
         this.invigilator_id = 'sbc'
       } else {


### PR DESCRIPTION
1) Fix the edit Group Exam Modal - display date and time
2) Disable Date and Time controls depending on your ROLE.
    Monthly Sessional:  if GA or ITA LIASON or OFFICE EXAM MANAGER  you are able to edit, otherwise no
    Environment or ITA Group Exams:   If you are an ITA Liaison or Environment Liaison you are able to edit, otherwise no
    Support can edit all exam dates and Times