### PR TITLE
emergency fix for send reminder emails - added parameter to get access token

### DIFF
--- a/jobs/appointment_reminder/send_email_reminder.py
+++ b/jobs/appointment_reminder/send_email_reminder.py
@@ -107,7 +107,7 @@ def send_reminders(app):
                 time.sleep(60)
                 email_count = 0
                 # To handle token expiry, get a new token when the task resumes.
-                access_token = get_access_token()
+                access_token = get_access_token(app)
 
     app.logger.debug('Ending job>>>')
 


### PR DESCRIPTION
send reminder emails were not being sent once we hit the maximum batch number.  temp solution in place.
this will fix it so we dont need to bump up max batch number