### PR TITLE
Cronable script for running Redis CLUSTER MEET

### DIFF
--- a/jobs/appointment_reminder/docker-entrypoint.sh
+++ b/jobs/appointment_reminder/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 function start_cron_jobs() {
   echo "Starting go-crond as a background task ..."
-  CRON_CMD="go-crond --allow-unprivileged --include=cron/"
+  CRON_CMD="go-crond -v --allow-unprivileged --include=cron/"
   exec ${CRON_CMD}
 }
 

--- a/jobs/appointment_reminder/docker-entrypoint.sh
+++ b/jobs/appointment_reminder/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 function start_cron_jobs() {
   echo "Starting go-crond as a background task ..."
-  CRON_CMD="go-crond -v --allow-unprivileged --include=cron/"
+  CRON_CMD="go-crond --allow-unprivileged --include=cron/"
   exec ${CRON_CMD}
 }
 

--- a/jobs/appointment_reminder/redis_cluster_meet.py
+++ b/jobs/appointment_reminder/redis_cluster_meet.py
@@ -1,0 +1,72 @@
+# Copyright © 2021 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Designed to be called by cron on a regular basis to heal the Redis cluster in
+# the event of restart of all pods. To keep the code as simple as possible, it
+# does a CLUSTER MEET every time it is called, even if the cluster is complete.
+#
+# Arguments are:
+#
+#  - Name of the statefulset, such as "redis-theq". This script relies on pods
+#    being named "redis-theq-0" through "redis-theq-5"
+#  - Hostname of the Redis service, such as "$REDIS_THEQ_SERVICE_HOST"
+#  - Port number of the Redis service, such as "$REDIS_THEQ_SERVICE_PORT_REDIS"
+#  - Password for authenticating to the Redis nodes, such as the "password"
+#    value in the "redis-theq-secret" secret.
+
+import json
+import requests
+import socket
+import sys
+
+redis_statefulset = sys.argv[1]
+redis_host = sys.argv[2]
+redis_port = sys.argv[3]
+redis_password = sys.argv[4]
+
+# The location of the authorization token needed to make Kubernetes API calls,
+# particularly pod get.
+auth_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+auth_token = open(auth_token_file).read()
+
+# The location of the file that tells us what namespace we're running in. Used
+# for Kubernetes API calls.
+namespace_file = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+namespace = open(namespace_file).read()
+
+# The Kubernetes API endpoint that will be used to get the information for the
+# Redis pods.
+api_endpoint = "https://kubernetes.default.svc/api/v1/namespaces/" + \
+               namespace + "/pods/"
+
+# The self-signed certificate that is used by the Kubernetes API.
+api_certificate_file = "/run/secrets/kubernetes.io/serviceaccount/" + \
+                       "service-ca.crt"
+
+# Open a socket to whatever Redis pod is on the load balancer.
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.connect((redis_host, int(redis_port)))
+s.send(("HELLO 3 AUTH default " + redis_password + "\n").encode())
+print(s.recv(1024).decode())
+
+# CLUSTER MEET with every IP, including itself (for code simplicity).
+for i in range(0, 6):
+    response = requests.get(api_endpoint + redis_statefulset + "-" + str(i),
+                            headers={"Authorization": "Bearer " + auth_token},
+                            verify=api_certificate_file)
+    ip = json.loads(response.content)["status"]["podIP"]
+    s.send(("CLUSTER MEET " + format(ip) + " " + redis_port + "\n").encode())
+    print(s.recv(1024).decode())
+
+s.close()

--- a/jobs/appointment_reminder/redis_cluster_meet.py
+++ b/jobs/appointment_reminder/redis_cluster_meet.py
@@ -21,7 +21,7 @@
 #  - Name of the statefulset, such as "redis-theq". This script relies on pods
 #    being named "redis-theq-0" through "redis-theq-5"
 #  - Hostname of the Redis service, such as "$REDIS_THEQ_SERVICE_HOST"
-#  - Port number of the Redis service, such as "$REDIS_THEQ_SERVICE_PORT_REDIS"
+#  - Port number of the Redis service, such as "$REDIS_THEQ_SERVICE_PORT"
 #  - Password for authenticating to the Redis nodes, such as the "password"
 #    value in the "redis-theq-secret" secret.
 
@@ -58,7 +58,7 @@ api_certificate_file = "/run/secrets/kubernetes.io/serviceaccount/" + \
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.connect((redis_host, int(redis_port)))
 s.send(("HELLO 3 AUTH default " + redis_password + "\n").encode())
-print(s.recv(1024).decode())
+# print(s.recv(1024).decode())
 
 # CLUSTER MEET with every IP, including itself (for code simplicity).
 for i in range(0, 6):
@@ -67,6 +67,6 @@ for i in range(0, 6):
                             verify=api_certificate_file)
     ip = json.loads(response.content)["status"]["podIP"]
     s.send(("CLUSTER MEET " + format(ip) + " " + redis_port + "\n").encode())
-    print(s.recv(1024).decode())
+    # print(s.recv(1024).decode())
 
 s.close()

--- a/openshift/templates/crond-send-appointment-reminder-deploy.yaml
+++ b/openshift/templates/crond-send-appointment-reminder-deploy.yaml
@@ -37,10 +37,10 @@ objects:
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role
-      name: ${NAME}-${TAG_NAME}
+      name: ${NAME}
     subjects:
       - kind: ServiceAccount
-        name: ${NAME}-${TAG_NAME}
+        name: ${NAME}
   - kind: ConfigMap
     apiVersion: v1
     metadata:

--- a/openshift/templates/crond-send-appointment-reminder-deploy.yaml
+++ b/openshift/templates/crond-send-appointment-reminder-deploy.yaml
@@ -6,6 +6,41 @@ metadata:
     tags: '${NAME}-${TAG_NAME}'
   name: '${NAME}-${TAG_NAME}-deploy'
 objects:
+  - kind: Role
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: ${NAME}-${TAG_NAME}
+      labels:
+        app: ${NAME}-${TAG_NAME}
+        app-group: ${APP_GROUP}
+    rules:
+      - apiGroups:
+          - ''
+        resources:
+          - pods
+        verbs:
+          - get
+  - kind: ServiceAccount
+    apiVersion: v1
+    metadata:
+      name: ${NAME}-${TAG_NAME}
+      labels:
+        app: ${NAME}-${TAG_NAME}
+        app-group: ${APP_GROUP}
+  - kind: RoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1
+    metadata:
+      name: ${NAME}-${TAG_NAME}
+      labels:
+        app: ${NAME}-${TAG_NAME}
+        app-group: ${APP_GROUP}
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: ${NAME}-${TAG_NAME}
+    subjects:
+      - kind: ServiceAccount
+        name: ${NAME}-${TAG_NAME}
   - kind: ConfigMap
     apiVersion: v1
     metadata:
@@ -76,6 +111,7 @@ objects:
             deploymentconfig: '${NAME}-${TAG_NAME}'
             template: '${NAME}-deploy'
         spec:
+          serviceAccountName: ${NAME}-${TAG_NAME}
           volumes:
             - name: cron-config
               configMap:

--- a/openshift/templates/crond-send-appointment-reminder-deploy.yaml
+++ b/openshift/templates/crond-send-appointment-reminder-deploy.yaml
@@ -9,9 +9,9 @@ objects:
   - kind: Role
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
-      name: ${NAME}-${TAG_NAME}
+      name: ${NAME}
       labels:
-        app: ${NAME}-${TAG_NAME}
+        app: ${NAME}
         app-group: ${APP_GROUP}
     rules:
       - apiGroups:
@@ -23,16 +23,16 @@ objects:
   - kind: ServiceAccount
     apiVersion: v1
     metadata:
-      name: ${NAME}-${TAG_NAME}
+      name: ${NAME}
       labels:
-        app: ${NAME}-${TAG_NAME}
+        app: ${NAME}
         app-group: ${APP_GROUP}
   - kind: RoleBinding
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
-      name: ${NAME}-${TAG_NAME}
+      name: ${NAME}
       labels:
-        app: ${NAME}-${TAG_NAME}
+        app: ${NAME}
         app-group: ${APP_GROUP}
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -111,7 +111,7 @@ objects:
             deploymentconfig: '${NAME}-${TAG_NAME}'
             template: '${NAME}-deploy'
         spec:
-          serviceAccountName: ${NAME}-${TAG_NAME}
+          serviceAccountName: ${NAME}
           volumes:
             - name: cron-config
               configMap:


### PR DESCRIPTION
New Python script to:
  - Connect to a Redis pod
  - Call CLUSTER MEET for all other Redis pods

Includes RBAC settings to run cron pod with elevated permissions to call Kubernetes API for pod get.