### PR TITLE
Booking modal bug fix

### DIFF
--- a/frontend/src/components/Booking/booking-modal.vue
+++ b/frontend/src/components/Booking/booking-modal.vue
@@ -429,7 +429,7 @@ export default class BookingModal extends Vue {
     this.pressedSubmit = false
     if (this.exam.notes) { this.notes = this.exam.notes.valueOf() }
     this.$nextTick(function () {
-      if (this.$refs.contact_information.focus) {
+      if (this.$refs.contact_information?.focus) {
         this.$refs.contact_information.focus()
       }
     })

--- a/frontend/src/components/Booking/booking-modal.vue
+++ b/frontend/src/components/Booking/booking-modal.vue
@@ -304,7 +304,7 @@ export default class BookingModal extends Vue {
       { key: 'Format of Exam:', value: this.exam.exam_method },
       { key: 'Length of Exam:', value: length },
       { key: 'ServiceBC to Provide Reader:', value: this.invigilatorRequired ? 'Yes' : 'No' },
-      { key: 'Room:', value: this.date.resource.title }
+      { key: 'Room:', value: this.date?.resource?.title }
     ]
     if (this.exam.exam_type.exam_type_name === 'Monthly Session Exam') {
       const i = items.findIndex(x => x.key === 'Exam Expiry:')
@@ -429,7 +429,7 @@ export default class BookingModal extends Vue {
     this.pressedSubmit = false
     if (this.exam.notes) { this.notes = this.exam.notes.valueOf() }
     this.$nextTick(function () {
-      if (this.$refs.contact_information) {
+      if (this.$refs.contact_information.focus) {
         this.$refs.contact_information.focus()
       }
     })

--- a/frontend/src/components/Booking/calendar.vue
+++ b/frontend/src/components/Booking/calendar.vue
@@ -628,7 +628,11 @@ export default class Calendar extends Vue {
     event.end = moment(event.start).add(defaultHoursDuration, 'h')
     // event.end = moment.tz(event.start, this.$store.state.user.office.timezone.timezone_name).add(defaultHoursDuration, 'h')
     const resourceDetails = this.roomResources.find(cat => {
-      return cat.title === event.category.categoryName
+      // Refer to getCategoryList():
+      // event.category is a string and it does not have a property named categoryName
+      // However, event.categoryName was added as part of Roombooking issue fix PR #555
+      // Hence this extended expression for equality to keep the changes passive.
+      return cat.title === event.category?.categoryName || cat.title === event.category
     })
     if (resourceDetails) { event.resource = resourceDetails }
 


### PR DESCRIPTION
**Root cause:**
* event.categoryName in calendar.vue was added as part of Roombooking issue fix PR #555
* event.category is a string and it does not have a property named categoryName

Hence this change to correct the behavior passively.