### PR TITLE
vue, vuetify, sass, vue-template-compiler version degraded- add other exam and ENV exam fix

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3777,6 +3777,26 @@
             }
           }
         },
+        "fork-ts-checker-webpack-plugin-v5": {
+          "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
+          "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
+          "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@babel/code-frame": "^7.8.3",
+            "@types/json-schema": "^7.0.5",
+            "chalk": "^4.1.0",
+            "cosmiconfig": "^6.0.0",
+            "deepmerge": "^4.2.2",
+            "fs-extra": "^9.0.0",
+            "memfs": "^3.1.2",
+            "minimatch": "^3.0.4",
+            "schema-utils": "2.7.0",
+            "semver": "^7.3.2",
+            "tapable": "^1.0.0"
+          }
+        },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -3876,6 +3896,18 @@
               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
               "dev": true
             }
+          }
+        },
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
           }
         },
         "slash": {
@@ -10787,40 +10819,6 @@
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
-          }
-        }
-      }
-    },
-    "fork-ts-checker-webpack-plugin-v5": {
-      "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
-      "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@types/json-schema": "^7.0.5",
-        "chalk": "^4.1.0",
-        "cosmiconfig": "^6.0.0",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^9.0.0",
-        "memfs": "^3.1.2",
-        "minimatch": "^3.0.4",
-        "schema-utils": "2.7.0",
-        "semver": "^7.3.2",
-        "tapable": "^1.0.0"
-      },
-      "dependencies": {
-        "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
           }
         }
       }
@@ -22969,8 +22967,7 @@
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "semver": {
           "version": "5.7.1",
@@ -22986,6 +22983,14 @@
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
+            }
           }
         }
       }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6935,13 +6935,26 @@
             "string-width": "^4.2.0",
             "y18n": "^5.0.5",
             "yargs-parser": "^20.2.2"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "15.0.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+              "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+              "dev": true,
+              "requires": {
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         },
         "yargs-parser": {
-          "version": "20.2.9",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-          "dev": true
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "requires": {
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
@@ -8040,8 +8053,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decimal.js": {
       "version": "10.3.1",
@@ -13844,13 +13856,23 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^18.1.2"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "15.0.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+              "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+              "dev": true,
+              "requires": {
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         },
         "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -13859,8 +13881,7 @@
             "camelcase": {
               "version": "5.3.1",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
             }
           }
         }
@@ -15226,13 +15247,23 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^18.1.2"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "15.0.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+              "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+              "dev": true,
+              "requires": {
+                "decamelize": "^1.2.0"
+              }
+            }
           }
         },
         "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -15241,8 +15272,7 @@
             "camelcase": {
               "version": "5.3.1",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
             }
           }
         }
@@ -22949,12 +22979,13 @@
           "dev": true
         },
         "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -25259,24 +25290,15 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
+        },
+        "yargs-parser": {
+          "version": "15.0.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "dev": true,
+          "requires": {
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6641,6 +6641,11 @@
           "version": "2.6.14",
           "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
           "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
+        },
+        "vuex": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
+          "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw=="
         }
       }
     },
@@ -23965,9 +23970,9 @@
       }
     },
     "vuex": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-2.5.0.tgz",
+      "integrity": "sha512-5oJPOJySBgSgSzoeO+gZB/BbN/XsapgIF6tz34UwJqnGZMQurzIO3B4KIBf862gfc9ya+oduY5sSkq+5/oOilQ=="
     },
     "vuex-class": {
       "version": "0.3.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1432,6 +1432,23 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@humanwhocodes/config-array": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+      "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+      "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+      "dev": true
+    },
     "@intervolga/optimize-cssnano-plugin": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@intervolga/optimize-cssnano-plugin/-/optimize-cssnano-plugin-1.0.6.tgz",
@@ -1598,9 +1615,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -1792,9 +1809,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -1835,9 +1852,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -1883,9 +1900,9 @@
           }
         },
         "@types/stack-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
-          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
+          "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
           "dev": true
         },
         "ansi-styles": {
@@ -2068,9 +2085,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -2153,9 +2170,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -2221,9 +2238,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -2762,9 +2779,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.12.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.5.tgz",
-      "integrity": "sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==",
+      "version": "15.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz",
+      "integrity": "sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -2780,9 +2797,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.0.tgz",
-      "integrity": "sha512-hkc1DATxFLQo4VxPDpMH1gCkPpBbpOoJ/4nhuXw4n63/0R6bCpQECj4+K226UJ4JO/eJQz+1mC2I7JsWanAdQw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.3.1.tgz",
+      "integrity": "sha512-NVkb4p4YjI8E3O6+1m8I+8JlMpFZwfSbPGdaw0wXuyPRTEz0SLKwBUWNSO7Maoi8tQMPC8JLZNWkrcKPI7/sLA==",
       "dev": true
     },
     "@types/q": {
@@ -2838,15 +2855,15 @@
       "dev": true
     },
     "@types/tapable": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.7.tgz",
-      "integrity": "sha512-0VBprVqfgFD7Ehb2vd8Lh9TG3jP98gvr8rgehQqzztZNI7o8zS8Ad4jyZneKELphpuE212D8J70LnSNQSyO6bQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz",
+      "integrity": "sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==",
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.0.tgz",
-      "integrity": "sha512-EGkrJD5Uy+Pg0NUR8uA4bJ5WMfljyad0G+784vLCNUkD+QwOJXUbBYExXfVGf7YtyzdQp3L/XMYcliB987kL5Q==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz",
+      "integrity": "sha512-O3MmRAk6ZuAKa9CHgg0Pr0+lUOqoMLpc9AS4R8ano2auvsg7IE8syF3Xh/NPr26TWklxYcqoEEFdzLLs1fV9PQ==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
@@ -2874,9 +2891,9 @@
       }
     },
     "@types/webpack": {
-      "version": "4.41.29",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.29.tgz",
-      "integrity": "sha512-6pLaORaVNZxiB3FSHbyBiWM7QdazAWda1zvAq4SbZObZqHSDbWLi62iFdblVea6SK9eyBIVp5yHhKt/yNQdR7Q==",
+      "version": "4.41.30",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.30.tgz",
+      "integrity": "sha512-GUHyY+pfuQ6haAfzu4S14F+R5iGRwN6b2FRNJY7U0NilmFAqbsOfK6j1HwuLBAqwRIT+pVdNDJGJ6e8rpp0KHA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -2896,9 +2913,9 @@
       }
     },
     "@types/webpack-dev-server": {
-      "version": "3.11.4",
-      "resolved": "https://registry.npmjs.org/@types/webpack-dev-server/-/webpack-dev-server-3.11.4.tgz",
-      "integrity": "sha512-DCKORHjqNNVuMIDWFrlljftvc9CL0+09p3l7lBpb8dRqgN5SmvkWCY4MPKxoI6wJgdRqohmoNbptkxqSKAzLRg==",
+      "version": "3.11.5",
+      "resolved": "https://registry.npmjs.org/@types/webpack-dev-server/-/webpack-dev-server-3.11.5.tgz",
+      "integrity": "sha512-vjsbQBW3fE5FDICkF3w3ZWFRXNwQdKt7JRPLmRy5W0KXlcuew4wgpKWXhgHS71iLNv7Z2PlY9dSSIaYg+bk+9w==",
       "dev": true,
       "requires": {
         "@types/connect-history-api-fallback": "*",
@@ -2909,15 +2926,15 @@
       }
     },
     "@types/webpack-env": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.0.tgz",
-      "integrity": "sha512-Fx+NpfOO0CpeYX2g9bkvX8O5qh9wrU1sOF4g8sft4Mu7z+qfe387YlyY8w8daDyDsKY5vUxM0yxkAYnbkRbZEw==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.2.tgz",
+      "integrity": "sha512-vKx7WNQNZDyJveYcHAm9ZxhqSGLYwoyLhrHjLBOkw3a7cT76sTdjgtwyijhk1MaHyRIuSztcVwrUOO/NEu68Dw==",
       "dev": true
     },
     "@types/webpack-sources": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.1.0.tgz",
-      "integrity": "sha512-LXn/oYIpBeucgP1EIJbKQ2/4ZmpvRl+dlrFdX7+94SKRUV3Evy3FsfMZY318vGhkWUS5MPhtOM3w1/hCOAOXcg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.1.1.tgz",
+      "integrity": "sha512-MjM1R6iuw8XaVbtkCBz0N349cyqBjJHCbQiOeppe3VBeFvxqs74RKHAVt9LkxTnUWc7YLZOEsUfPUnmK6SBPKQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -2934,24 +2951,24 @@
       }
     },
     "@types/yargs": {
-      "version": "15.0.13",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz",
-      "integrity": "sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==",
+      "version": "15.0.14",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.14.tgz",
+      "integrity": "sha512-yEJzHoxf6SyQGhBhIYGXQDSCkJjB6HohDShto7m8vaKg9Yp0Yn8+71J9eakh2bnPg6BfsH9PRMhiRTZnd4eXGQ==",
       "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
     },
     "@types/yargs-parser": {
-      "version": "20.2.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
-      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==",
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.1.tgz",
+      "integrity": "sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==",
       "dev": true
     },
     "@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3933,9 +3950,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -5433,9 +5450,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -6618,6 +6635,13 @@
         "vue2-datepicker": "^3.9.0",
         "vuex": "3.6.2",
         "vuex-class": "^0.3.2"
+      },
+      "dependencies": {
+        "vue": {
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+          "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
+        }
       }
     },
     "caniuse-api": {
@@ -6911,26 +6935,13 @@
             "string-width": "^4.2.0",
             "y18n": "^5.0.5",
             "yargs-parser": "^20.2.2"
-          },
-          "dependencies": {
-            "yargs-parser": {
-              "version": "15.0.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-              "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-              "dev": true,
-              "requires": {
-                "decamelize": "^1.2.0"
-              }
-            }
           }
         },
         "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-          "requires": {
-            "decamelize": "^1.2.0"
-          }
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+          "dev": true
         }
       }
     },
@@ -8029,7 +8040,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decimal.js": {
       "version": "10.3.1",
@@ -8696,9 +8708,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.763",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.763.tgz",
-      "integrity": "sha512-UyvEPae0wvzsyNJhVfGeFSOlUkHEze8xSIiExO5tZQ8QTr7obFiJWGk3U4e7afFOJMQJDszqU/3Pk5jtKiaSEg=="
+      "version": "1.3.766",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.766.tgz",
+      "integrity": "sha512-u2quJ862q9reRKh/je3GXis3w38+RoXH1J9N3XjtsS6NzmUAosNsyZgUVFZPN/ZlJ3v6T0rTyZR3q/J5c6Sy5w=="
     },
     "elliptic": {
       "version": "6.5.4",
@@ -8990,13 +9002,14 @@
       }
     },
     "eslint": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.29.0.tgz",
-      "integrity": "sha512-82G/JToB9qIy/ArBzIWG9xvvwL3R86AlCjtGw+A29OMZDqhTybz/MByORSukGxeI+YPCR4coYyITKk8BFH9nDA==",
+      "version": "7.30.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.30.0.tgz",
+      "integrity": "sha512-VLqz80i3as3NdloY44BQSJpFw534L9Oh+6zJOUaViV4JPd+DaHwutqP7tcpkW3YiXbK6s05RZl7yl7cQn+lijg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.2",
+        "@humanwhocodes/config-array": "^0.5.0",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -10039,9 +10052,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -10577,9 +10590,9 @@
       }
     },
     "flatted": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.0.tgz",
+      "integrity": "sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==",
       "dev": true
     },
     "flush-write-stream": {
@@ -10812,29 +10825,29 @@
       }
     },
     "formiojs": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.13.2.tgz",
-      "integrity": "sha512-HZeq5h2P2BPwhSDbENHM6TVjJCoHdhz53sGxORIRXkzt2/GTErjrh6CuejrflLYdWuS1YRy0qjYuxIS/2P40+A==",
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/formiojs/-/formiojs-4.13.3.tgz",
+      "integrity": "sha512-7m8vi5/OLec1db0LJSRTknNNRCZQWec7Qncp396RmMGI+uSBaz9wfPSQkZ5t7uvPLfWn6QfBQ7vHzBzq+rnX4w==",
       "requires": {
-        "@formio/bootstrap3": "^2.11.0",
+        "@formio/bootstrap3": "^2.11.3",
         "@formio/choices.js": "^9.0.1",
-        "@formio/semantic": "^2.5.1",
+        "@formio/semantic": "^2.5.3",
         "@formio/vanilla-text-mask": "^5.1.1",
         "autocompleter": "^6.1.0",
         "browser-cookies": "^1.2.0",
         "compare-versions": "^3.6.0",
-        "core-js": "^3.13.0",
+        "core-js": "^3.15.2",
         "custom-event-polyfill": "^1.0.7",
         "dialog-polyfill": "^0.5.6",
-        "dompurify": "^2.2.8",
+        "dompurify": "^2.2.9",
         "downloadjs": "^1.4.7",
         "dragula": "^3.7.3",
         "eventemitter3": "^4.0.7",
         "fast-deep-equal": "^3.1.3",
         "fast-json-patch": "^2.2.1",
         "fetch-ponyfill": "^7.1.0",
-        "i18next": "^20.3.0",
-        "idb": "^6.1.1",
+        "i18next": "^20.3.2",
+        "idb": "^6.1.2",
         "ismobilejs": "^1.1.1",
         "json-logic-js": "^2.0.0",
         "jstimezonedetect": "^1.0.7",
@@ -12704,9 +12717,9 @@
           }
         },
         "@types/stack-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
-          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
+          "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
           "dev": true
         },
         "acorn": {
@@ -13831,23 +13844,13 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^18.1.2"
-          },
-          "dependencies": {
-            "yargs-parser": {
-              "version": "15.0.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-              "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-              "dev": true,
-              "requires": {
-                "decamelize": "^1.2.0"
-              }
-            }
           }
         },
         "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -13856,7 +13859,8 @@
             "camelcase": {
               "version": "5.3.1",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
             }
           }
         }
@@ -13895,9 +13899,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -14095,9 +14099,9 @@
           }
         },
         "@types/stack-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
-          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
+          "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
           "dev": true
         },
         "acorn": {
@@ -15222,23 +15226,13 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^18.1.2"
-          },
-          "dependencies": {
-            "yargs-parser": {
-              "version": "15.0.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-              "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-              "dev": true,
-              "requires": {
-                "decamelize": "^1.2.0"
-              }
-            }
           }
         },
         "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -15247,7 +15241,8 @@
             "camelcase": {
               "version": "5.3.1",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
             }
           }
         }
@@ -15300,9 +15295,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -15510,9 +15505,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -15597,9 +15592,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -15643,9 +15638,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -15779,9 +15774,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -15837,9 +15832,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16026,9 +16021,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16103,9 +16098,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16177,9 +16172,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16284,9 +16279,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16445,9 +16440,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16502,9 +16497,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16556,9 +16551,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16615,9 +16610,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16689,9 +16684,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16774,9 +16769,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16897,9 +16892,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -16981,9 +16976,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -17128,9 +17123,9 @@
           }
         },
         "@types/yargs": {
-          "version": "13.0.11",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
-          "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+          "version": "13.0.12",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.12.tgz",
+          "integrity": "sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==",
           "dev": true,
           "requires": {
             "@types/yargs-parser": "*"
@@ -18526,9 +18521,9 @@
       "dev": true
     },
     "node-ipc": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.1.4.tgz",
-      "integrity": "sha512-A+f0mn2KxUt1uRTSd5ktxQUsn2OEhj5evo7NUi/powBzMSZ0vocdzDjlq9QN2v3LH6CJi3e5xAenpZ1QwU5A8g==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.2.1.tgz",
+      "integrity": "sha512-mJzaM6O3xHf9VT8BULvJSbdVbmHUKRNOH7zDDkCrA1/T+CVjq2WVIDfLt0azZRXpgArJtl3rtmEozrbXPZ9GaQ==",
       "dev": true,
       "requires": {
         "event-pubsub": "4.3.0",
@@ -21347,9 +21342,9 @@
       }
     },
     "sass": {
-      "version": "1.35.1",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.35.1.tgz",
-      "integrity": "sha512-oCisuQJstxMcacOPmxLNiLlj4cUyN2+8xJnG7VanRoh2GOLr9RqkvI4AxA4a6LHVg/rsu+PmxXeGhrdSF9jCiQ==",
+      "version": "1.32.13",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
+      "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
@@ -22954,13 +22949,12 @@
           "dev": true
         },
         "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -23718,9 +23712,9 @@
       "dev": true
     },
     "vue": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
-      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.12.tgz",
+      "integrity": "sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg=="
     },
     "vue-bootstrap-typeahead": {
       "version": "0.2.6",
@@ -23748,23 +23742,30 @@
       }
     },
     "vue-eslint-parser": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.6.0.tgz",
-      "integrity": "sha512-QXxqH8ZevBrtiZMZK0LpwaMfevQi9UL7lY6Kcp+ogWHC88AuwUPwwCIzkOUc1LR4XsYAt/F9yHXAB/QoD17QXA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.7.2.tgz",
+      "integrity": "sha512-zkfxSttpwBW9SQEa+rLR+j6sFHGGhanVH3VuzHQwybCQWJsg/Yi1W619gXOW01U/zekN4D+J4/S4Zufd1sClZg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "eslint-scope": "^5.0.0",
+        "eslint-scope": "^5.1.1",
         "eslint-visitor-keys": "^1.1.0",
         "espree": "^6.2.1",
         "esquery": "^1.4.0",
-        "lodash": "^4.17.15"
+        "lodash": "^4.17.21",
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
           "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -23894,9 +23895,9 @@
       }
     },
     "vue-template-compiler": {
-      "version": "2.6.14",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.14.tgz",
-      "integrity": "sha512-ODQS1SyMbjKoO1JBJZojSw6FE4qnh9rIpUZn2EUT86FKizx9uH5z6uXiIrm4/Nb/gwxTi/o17ZDEGWAXHvtC7g==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.6.12.tgz",
+      "integrity": "sha512-OzzZ52zS41YUbkCBfdXShQTe69j1gQDZ9HIX8miuC9C3rBCk9wIRjLiZZLrmX9V+Ftq/YEyv1JaVr5Y/hNtByg==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",
@@ -23935,9 +23936,9 @@
       "integrity": "sha512-DhO2UH4CTer/lMWxg+jqxn/+h6g2vZrsM6vCe9u7/Ie+Pej9yA+8mQA3C3VPApZ+LauKc43WxCspOXb6SGBOTw=="
     },
     "vuetify": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.5.6.tgz",
-      "integrity": "sha512-2T8ML5PYuJ/AdMVH3ZIvzHnsM0nX8t4Xzj+0HFFGfLT7jLlptCFpG+JE8+kyrgGZlbUgulyOwCUu8hJkVsReFA=="
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-2.4.8.tgz",
+      "integrity": "sha512-rJYyzSO4Qsm/Q79W4FAUedgIDzUvx2uXzXXQ7OB2z9kAAkVOpTdMFY0CnpBcvlYbXOYy/mJ81/yUCV1ZAvJ3FQ=="
     },
     "vuetify-loader": {
       "version": "1.7.2",
@@ -25258,15 +25259,24 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
-        },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-          "dev": true,
-          "requires": {
-            "decamelize": "^1.2.0"
-          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
         }
       }
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2779,9 +2779,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "15.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.0.tgz",
-      "integrity": "sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.0.0.tgz",
+      "integrity": "sha512-TmCW5HoZ2o2/z2EYi109jLqIaPIi9y/lc2LmDCWzuCi35bcaQ+OtUh6nwBiFK7SOu25FAU5+YKdqFZUwtqGSdg==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -3777,26 +3777,6 @@
             }
           }
         },
-        "fork-ts-checker-webpack-plugin-v5": {
-          "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
-          "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
-          "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@babel/code-frame": "^7.8.3",
-            "@types/json-schema": "^7.0.5",
-            "chalk": "^4.1.0",
-            "cosmiconfig": "^6.0.0",
-            "deepmerge": "^4.2.2",
-            "fs-extra": "^9.0.0",
-            "memfs": "^3.1.2",
-            "minimatch": "^3.0.4",
-            "schema-utils": "2.7.0",
-            "semver": "^7.3.2",
-            "tapable": "^1.0.0"
-          }
-        },
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -3896,18 +3876,6 @@
               "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
               "dev": true
             }
-          }
-        },
-        "schema-utils": {
-          "version": "2.7.0",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "@types/json-schema": "^7.0.4",
-            "ajv": "^6.12.2",
-            "ajv-keywords": "^3.4.1"
           }
         },
         "slash": {
@@ -6967,26 +6935,13 @@
             "string-width": "^4.2.0",
             "y18n": "^5.0.5",
             "yargs-parser": "^20.2.2"
-          },
-          "dependencies": {
-            "yargs-parser": {
-              "version": "15.0.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-              "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-              "dev": true,
-              "requires": {
-                "decamelize": "^1.2.0"
-              }
-            }
           }
         },
         "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-          "requires": {
-            "decamelize": "^1.2.0"
-          }
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+          "dev": true
         }
       }
     },
@@ -8085,7 +8040,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "decimal.js": {
       "version": "10.3.1",
@@ -10819,6 +10775,40 @@
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "fork-ts-checker-webpack-plugin-v5": {
+      "version": "npm:fork-ts-checker-webpack-plugin@5.2.1",
+      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-5.2.1.tgz",
+      "integrity": "sha512-SVi+ZAQOGbtAsUWrZvGzz38ga2YqjWvca1pXQFUArIVXqli0lLoDQ8uS0wg0kSpcwpZmaW5jVCZXQebkyUQSsw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@types/json-schema": "^7.0.5",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^6.0.0",
+        "deepmerge": "^4.2.2",
+        "fs-extra": "^9.0.0",
+        "memfs": "^3.1.2",
+        "minimatch": "^3.0.4",
+        "schema-utils": "2.7.0",
+        "semver": "^7.3.2",
+        "tapable": "^1.0.0"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "2.7.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+          "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "@types/json-schema": "^7.0.4",
+            "ajv": "^6.12.2",
+            "ajv-keywords": "^3.4.1"
           }
         }
       }
@@ -13854,23 +13844,13 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^18.1.2"
-          },
-          "dependencies": {
-            "yargs-parser": {
-              "version": "15.0.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-              "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-              "dev": true,
-              "requires": {
-                "decamelize": "^1.2.0"
-              }
-            }
           }
         },
         "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -13879,7 +13859,8 @@
             "camelcase": {
               "version": "5.3.1",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
             }
           }
         }
@@ -15245,23 +15226,13 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^18.1.2"
-          },
-          "dependencies": {
-            "yargs-parser": {
-              "version": "15.0.1",
-              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-              "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-              "dev": true,
-              "requires": {
-                "decamelize": "^1.2.0"
-              }
-            }
           }
         },
         "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -15270,7 +15241,8 @@
             "camelcase": {
               "version": "5.3.1",
               "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
             }
           }
         }
@@ -22967,7 +22939,8 @@
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
         },
         "semver": {
           "version": "5.7.1",
@@ -22976,21 +22949,12 @@
           "dev": true
         },
         "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
-            }
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -25295,15 +25259,24 @@
           "requires": {
             "ansi-regex": "^4.1.0"
           }
-        },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-          "dev": true,
-          "requires": {
-            "decamelize": "^1.2.0"
-          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
         }
       }
     },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6641,11 +6641,6 @@
           "version": "2.6.14",
           "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
           "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
-        },
-        "vuex": {
-          "version": "3.6.2",
-          "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
-          "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw=="
         }
       }
     },
@@ -23970,9 +23965,9 @@
       }
     },
     "vuex": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-2.5.0.tgz",
-      "integrity": "sha512-5oJPOJySBgSgSzoeO+gZB/BbN/XsapgIF6tz34UwJqnGZMQurzIO3B4KIBf862gfc9ya+oduY5sSkq+5/oOilQ=="
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.6.2.tgz",
+      "integrity": "sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw=="
     },
     "vuex-class": {
       "version": "0.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,8 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --mode production",
     "lint": "vue-cli-service lint",
-    "test:unit": "vue-cli-service test:unit"
+    "test:unit": "vue-cli-service test:unit",
+    "preinstall": "npx npm-force-resolutions"
   },
   "resolutions": {
     "yargs-parser": "15.0.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,7 @@
     "vue2-datepicker": "^3.9.0",
     "vue2-timepicker": "^1.1.6",
     "vuetify": "2.4.8",
-    "vuex": "2.5",
+    "vuex": "3.6.2",
     "vuex-class": "^0.3.2",
     "vuex-module-decorators": "^1.0.1"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -61,7 +61,7 @@
     "vue2-datepicker": "^3.9.0",
     "vue2-timepicker": "^1.1.6",
     "vuetify": "2.4.8",
-    "vuex": "3.6.2",
+    "vuex": "^3.6.2",
     "vuex-class": "^0.3.2",
     "vuex-module-decorators": "^1.0.1"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --mode production",
     "lint": "vue-cli-service lint",
-    "test:unit": "vue-cli-service test:unit",
-    "preinstall": "npx npm-force-resolutions"
+    "test:unit": "vue-cli-service test:unit"
   },
   "resolutions": {
     "yargs-parser": "15.0.1"
@@ -61,7 +60,7 @@
     "vue2-datepicker": "^3.9.0",
     "vue2-timepicker": "^1.1.6",
     "vuetify": "2.4.8",
-    "vuex": "^3.6.2",
+    "vuex": "2.5",
     "vuex-class": "^0.3.2",
     "vuex-module-decorators": "^1.0.1"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,8 +15,7 @@
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build --mode production",
     "lint": "vue-cli-service lint",
-    "test:unit": "vue-cli-service test:unit",
-    "preinstall": "npx npm-force-resolutions"
+    "test:unit": "vue-cli-service test:unit"
   },
   "resolutions": {
     "yargs-parser": "15.0.1"
@@ -51,7 +50,7 @@
     "uuid": "8.3.2",
     "uuidv4": "^6.2.7",
     "v-dragged": "0.0.5",
-    "vue": "^2.6.12",
+    "vue": "2.6.12",
     "vue-bootstrap-typeahead": "^0.2.6",
     "vue-class-component": "^7.2.3",
     "vue-fragment": "1.5.2",
@@ -60,7 +59,7 @@
     "vue-video-player": "5.0.2",
     "vue2-datepicker": "^3.9.0",
     "vue2-timepicker": "^1.1.6",
-    "vuetify": "^2.4.8",
+    "vuetify": "2.4.8",
     "vuex": "3.6.2",
     "vuex-class": "^0.3.2",
     "vuex-module-decorators": "^1.0.1"
@@ -117,7 +116,7 @@
     "postcss-loader": "4.0.3",
     "puppeteer": "8.0.0",
     "rimraf": "3.0.2",
-    "sass": "^1.22.10",
+    "sass": "1.32",
     "sass-loader": "^10.1.1",
     "semver": "7.3.5",
     "shelljs": "0.8.4",
@@ -126,7 +125,7 @@
     "vue-cli-plugin-vuetify": "^2.0.7",
     "vue-loader": "15.9.6",
     "vue-style-loader": "4.1.3",
-    "vue-template-compiler": "^2.6.14",
+    "vue-template-compiler": "2.6.12",
     "vuetify-loader": "^1.3.0"
   },
   "engines": {

--- a/frontend/src/store/modules/add-exam-module.ts
+++ b/frontend/src/store/modules/add-exam-module.ts
@@ -349,6 +349,7 @@ export const addExamModule = {
       }
     },
     addPesticideSteps (state, getters) {
+      console.log("getters==========>>>", getters)
       return [
         ...getters.pesticideStep1,
         ...getters.pesticideStep2,

--- a/frontend/src/store/modules/add-exam-module.ts
+++ b/frontend/src/store/modules/add-exam-module.ts
@@ -264,7 +264,6 @@ export const addExamModule = {
       })
     },
     getPesticideExamTypes ({ commit, rootState }) {
-      console.log('getPesticideExamTypes')
       return new Promise<void>((resolve, reject) => {
         const url = '/exam_types/'
 
@@ -349,7 +348,6 @@ export const addExamModule = {
       }
     },
     addPesticideSteps (state, getters) {
-      console.log("getters==========>>>", getters)
       return [
         ...getters.pesticideStep1,
         ...getters.pesticideStep2,

--- a/frontend/src/store/mutations/mutations-model.ts
+++ b/frontend/src/store/mutations/mutations-model.ts
@@ -11,89 +11,89 @@
  *
  */
 
-import { StateModelIF } from '@/interfaces'
-import Vue from 'vue'
-let _default_counter_id = null
+import { StateModelIF } from "@/interfaces";
+import Vue from "vue";
+let _default_counter_id = null;
 
 export const commonMutation: any = {
   logIn: state => (state.isLoggedIn = true),
   logOut: state => (state.isLoggedIn = false),
   setBearer: (state, payload) => (state.bearer = payload),
   setUser: (state, payload) => (state.user = payload),
-  updateQueue (state, payload) {
-    state.citizens = []
-    state.citizens = payload
+  updateQueue(state, payload) {
+    state.citizens = [];
+    state.citizens = payload;
   },
-  setServices (state, payload) {
-    state.services = {}
-    state.services = payload
+  setServices(state, payload) {
+    state.services = {};
+    state.services = payload;
   },
-  setChannels (state, payload) {
-    state.channels = []
-    state.channels = payload
+  setChannels(state, payload) {
+    state.channels = [];
+    state.channels = payload;
   },
-  setCategories (state, payload) {
-    state.categories = []
-    state.categories = payload
+  setCategories(state, payload) {
+    state.categories = [];
+    state.categories = payload;
   },
 
   setReturnExamInfo: (state, payload) => (state.returnExam = payload),
 
-  setManifestData (state, payload) {
-    state.manifestdata = ''
-    state.manifestdata = payload
+  setManifestData(state, payload) {
+    state.manifestdata = "";
+    state.manifestdata = payload;
   },
 
-  setDiskSpace (state, payload) {
-    state.diskspace = {}
-    state.diskspace = payload
+  setDiskSpace(state, payload) {
+    state.diskspace = {};
+    state.diskspace = payload;
   },
 
-  setIsUploadingFile (state, payload) {
-    state.isUploadingFile = payload
+  setIsUploadingFile(state, payload) {
+    state.isUploadingFile = payload;
   },
 
-  setVideoFiles (state, payload) {
-    state.videofiles = []
-    state.videofiles = payload
+  setVideoFiles(state, payload) {
+    state.videofiles = [];
+    state.videofiles = payload;
   },
 
   toggleAddModal: (state, payload) => (state.showAddModal = payload),
 
-  updateAddModalForm (state, payload) {
-    Vue.set(state.addModalForm, payload.type, payload.value)
+  updateAddModalForm(state, payload) {
+    Vue.set(state.addModalForm, payload.type, payload.value);
   },
 
-  setAddModalSelectedItem (state, payload) {
-    state.addModalForm.suspendFilter = true
-    state.addModalForm.selectedItem = payload
+  setAddModalSelectedItem(state, payload) {
+    state.addModalForm.suspendFilter = true;
+    state.addModalForm.selectedItem = payload;
   },
 
-  resetAddModalForm (state) {
-    const keys = Object.keys(state.addModalForm)
+  resetAddModalForm(state) {
+    const keys = Object.keys(state.addModalForm);
     keys.forEach(key => {
       switch (key) {
-      case 'suspendFilter':
-        Vue.set(state.addModalForm, key, false)
-        break
-      case 'priority':
-        Vue.set(state.addModalForm, key, 2)
-        break
-      case 'counter':
-        Vue.set(state.addModalForm, key, _default_counter_id)
-        break
-      default:
-        Vue.set(state.addModalForm, key, '')
+        case "suspendFilter":
+          Vue.set(state.addModalForm, key, false);
+          break;
+        case "priority":
+          Vue.set(state.addModalForm, key, 2);
+          break;
+        case "counter":
+          Vue.set(state.addModalForm, key, _default_counter_id);
+          break;
+        default:
+          Vue.set(state.addModalForm, key, "");
       }
-    })
+    });
   },
 
-  switchAddModalMode (state, payload) {
-    state.addModalSetup = payload
+  switchAddModalMode(state, payload) {
+    state.addModalSetup = payload;
   },
 
-  setAddModalData (state, data) {
-    const { citizen, active_service } = data
+  setAddModalData(state, data) {
+    const { citizen, active_service } = data;
 
     const formData = {
       comments: citizen.citizen_comments,
@@ -104,19 +104,18 @@ export const commonMutation: any = {
       notification_phone: citizen.notification_phone,
       notification_email: citizen.notification_email,
       walkin_unique_id: citizen.walkin_unique_id
-    }
-    const keys = Object.keys(formData)
+    };
+    const keys = Object.keys(formData);
     keys.forEach(key => {
-      Vue.set(state.addModalForm, key, formData[key])
-    })
+      Vue.set(state.addModalForm, key, formData[key]);
+    });
   },
 
   toggleServiceModal: (state, payload) => (state.showServiceModal = payload),
 
   setDisplayServices: (state, payload) => (state.displayServices = payload),
 
-  setBackOfficeDisplay: (state, payload) =>
-    (state.backOfficeDisplay = payload),
+  setBackOfficeDisplay: (state, payload) => (state.backOfficeDisplay = payload),
 
   setRecurringFeatureFlag: (state, payload) =>
     (state.recurringFeatureFlag = payload),
@@ -127,16 +126,16 @@ export const commonMutation: any = {
   toggleEditDeleteSeries: (state, payload) =>
     (state.editDeleteSeries = payload),
 
-  setServiceModalForm (state, citizen) {
-    const citizen_comments = citizen.citizen_comments
+  setServiceModalForm(state, citizen) {
+    const citizen_comments = citizen.citizen_comments;
     const activeService = citizen.service_reqs.filter(sr =>
       sr.periods.some(p => p.time_end === null)
-    )
-    const activeQuantity = activeService[0].quantity
-    const { citizen_id } = citizen
-    const service_citizen = citizen
-    const priority = citizen.priority
-    const counter = citizen.counter_id
+    );
+    const activeQuantity = activeService[0].quantity;
+    const { citizen_id } = citizen;
+    const service_citizen = citizen;
+    const priority = citizen.priority;
+    const counter = citizen.counter_id;
 
     const obj = {
       citizen_comments,
@@ -145,153 +144,152 @@ export const commonMutation: any = {
       service_citizen,
       priority,
       counter
-    }
-    const keys = Object.keys(obj)
+    };
+    const keys = Object.keys(obj);
 
     keys.forEach(key => {
-      Vue.set(state.serviceModalForm, key, obj[key])
-    })
+      Vue.set(state.serviceModalForm, key, obj[key]);
+    });
   },
 
-  resetServiceModal (state) {
-    const { serviceModalForm } = state
-    const keys = Object.keys(serviceModalForm)
-    Vue.set(state, 'serveModalAlert', '')
+  resetServiceModal(state) {
+    const { serviceModalForm } = state;
+    const keys = Object.keys(serviceModalForm);
+    Vue.set(state, "serveModalAlert", "");
 
     keys.forEach(key => {
-      if (key === 'activeQuantity') {
-        Vue.set(state.serviceModalForm, key, 1)
+      if (key === "activeQuantity") {
+        Vue.set(state.serviceModalForm, key, 1);
       } else {
-        Vue.set(state.serviceModalForm, key, null)
+        Vue.set(state.serviceModalForm, key, null);
       }
-    })
+    });
   },
 
-  editServiceModalForm (state, payload) {
-    Vue.set(state.serviceModalForm, payload.type, payload.value)
+  editServiceModalForm(state, payload) {
+    Vue.set(state.serviceModalForm, payload.type, payload.value);
   },
 
-  setDefaultChannel (state) {
+  setDefaultChannel(state) {
     const channel = state.channels.filter(
-      ch => ch.channel_name === 'In Person'
-    )
-    state.addModalForm.channel = channel[0].channel_id
+      ch => ch.channel_name === "In Person"
+    );
+    state.addModalForm.channel = channel[0].channel_id;
   },
 
-  setMainAlert (state, payload) {
-    state.alertMessage = payload
-    state.dismissCount = 5
+  setMainAlert(state, payload) {
+    state.alertMessage = payload;
+    state.dismissCount = 5;
   },
 
-  setSelectedOffice (state, payload) {
-    state.selectedOffice = payload
+  setSelectedOffice(state, payload) {
+    state.selectedOffice = payload;
   },
 
-  setExamAlert (state, payload) {
-    state.examAlertMessage = payload
+  setExamAlert(state, payload) {
+    state.examAlertMessage = payload;
     if (payload) {
-      state.examDismissCount = 999
+      state.examDismissCount = 999;
     } else {
-      state.examDismissCount = 0
+      state.examDismissCount = 0;
     }
   },
 
-  setLoginAlert (state, payload) {
-    state.loginAlertMessage = payload
-    state.loginDismissCount = 999
+  setLoginAlert(state, payload) {
+    state.loginAlertMessage = payload;
+    state.loginDismissCount = 999;
   },
 
-  setExamEditSuccessCount (state, payload) {
-    state.examEditSuccessCount = payload
+  setExamEditSuccessCount(state, payload) {
+    state.examEditSuccessCount = payload;
   },
 
-  setExamEditFailureCount (state, payload) {
-    state.examEditFailCount = payload
+  setExamEditFailureCount(state, payload) {
+    state.examEditFailCount = payload;
   },
 
-  setModalAlert (state, payload) {
-    state.alertMessage = payload
+  setModalAlert(state, payload) {
+    state.alertMessage = payload;
   },
 
-  setServeModalAlert (state, payload) {
-    state.serveModalAlert = payload
+  setServeModalAlert(state, payload) {
+    state.serveModalAlert = payload;
   },
 
-  setCsrs (state, payload) {
-    state.csrs = []
-    state.csrs = payload
+  setCsrs(state, payload) {
+    state.csrs = [];
+    state.csrs = payload;
   },
 
-  setExams (state, payload) {
-    state.exams = []
-    state.exams = payload
+  setExams(state, payload) {
+    state.exams = [];
+    state.exams = payload;
   },
 
-  setEventWarning (state, payload) {
-    state.event_id_warning = payload
+  setEventWarning(state, payload) {
+    state.event_id_warning = payload;
   },
 
-  setExamEventIDs (state, payload) {
-    state.event_ids = payload
+  setExamEventIDs(state, payload) {
+    state.event_ids = payload;
   },
 
-  setExamTypes (state, payload) {
-    state.examTypes = []
-    state.examTypes = payload
+  setExamTypes(state, payload) {
+    state.examTypes = [];
+    state.examTypes = payload;
   },
 
-  setInvigilators (state, payload) {
-    state.invigilators = payload
+  setInvigilators(state, payload) {
+    state.invigilators = payload;
   },
 
-  setPesticideInvigilators (state, payload) {
-    state.pesticide_invigilators = payload
+  setPesticideInvigilators(state, payload) {
+    state.pesticide_invigilators = payload;
   },
 
-  setPesticideOffsiteInvigilators (state, payload) {
-    state.pesticide_offsite_invigilators = payload
+  setPesticideOffsiteInvigilators(state, payload) {
+    state.pesticide_offsite_invigilators = payload;
   },
 
-  updateCitizen (state, payload) {
-    Vue.set(state.citizens, payload.index, payload.citizen)
+  updateCitizen(state, payload) {
+    Vue.set(state.citizens, payload.index, payload.citizen);
   },
 
-  addCitizen (state, citizen) {
-    state.citizens.push(citizen)
+  addCitizen(state, citizen) {
+    state.citizens.push(citizen);
   },
 
-  dismissCountDown (state, payload) {
-    state.dismissCount = payload
+  dismissCountDown(state, payload) {
+    state.dismissCount = payload;
   },
 
-  examDismissCountDown (state, payload) {
-    state.examDismissCount = payload
+  examDismissCountDown(state, payload) {
+    state.examDismissCount = payload;
   },
 
-  loginDismissCountDown (state, payload) {
-    state.loginDismissCount = payload
+  loginDismissCountDown(state, payload) {
+    state.loginDismissCount = payload;
   },
 
-  examSuccessCountDown (state, payload) {
-    state.examSuccessDismiss = payload
+  examSuccessCountDown(state, payload) {
+    state.examSuccessDismiss = payload;
   },
 
   toggleInvitedStatus: (state, payload) => (state.citizenInvited = payload),
 
   toggleBegunStatus: (state, payload) => (state.serviceBegun = payload),
 
-  toggleGAScreenModal: (state, payload) =>
-    (state.showGAScreenModal = payload),
+  toggleGAScreenModal: (state, payload) => (state.showGAScreenModal = payload),
 
   toggleAgendaScreenModal: (state, payload) =>
     (state.showAgendaScreenModal = payload),
 
   setReceptionistState: (state, payload) => {
-    state.user.receptionist_ind = payload
+    state.user.receptionist_ind = payload;
   },
 
   setCounterStatusState: (state, payload) => {
-    state.user.counter_id = payload
+    state.user.counter_id = payload;
   },
 
   setCSRState: (state, payload) => (state.user.csr_state_id = payload),
@@ -312,20 +310,20 @@ export const commonMutation: any = {
   /**
    * Change the office a CSR is currently assigned to.
    */
-  changeCSROffice: (state: StateModelIF, payload) => (state.user.office = payload),
+  changeCSROffice: (state: StateModelIF, payload) =>
+    (state.user.office = payload),
 
   setDefaultCounter: (state, defaultCounter) => {
-    state.addModalForm.counter = defaultCounter.counter_id
-    state.serviceModalForm.counter = defaultCounter.counter_id
-    _default_counter_id = defaultCounter.counter_id
+    state.addModalForm.counter = defaultCounter.counter_id;
+    state.serviceModalForm.counter = defaultCounter.counter_id;
+    _default_counter_id = defaultCounter.counter_id;
   },
 
   flashServeNow: (state, payload) => (state.serveNowStyle = payload),
 
   setServeNowAction: (state, payload) => (state.serveNowAltAction = payload),
 
-  toggleFeedbackModal: (state, payload) =>
-    (state.showFeedbackModal = payload),
+  toggleFeedbackModal: (state, payload) => (state.showFeedbackModal = payload),
 
   toggleAddNextService: (state, payload) => (state.addNextService = payload),
 
@@ -344,29 +342,31 @@ export const commonMutation: any = {
 
   setIndividualExam: (state, payload) => (state.individualExam = payload),
 
-  showHideResponseModal (state) {
-    state.showResponseModal = true
+  showHideResponseModal(state) {
+    state.showResponseModal = true;
     setTimeout(() => {
-      state.showResponseModal = false
-    }, 3000)
+      state.showResponseModal = false;
+    }, 3000);
   },
 
-  hideResponseModal (state) {
-    state.showResponseModal = false
+  hideResponseModal(state) {
+    state.showResponseModal = false;
   },
 
   setiframeLogedIn: (state, value) => (state.iframeLogedIn = value),
 
   setNavigation: (state, value) => (state.adminNavigation = value),
 
-  setAddExamModalSetting (state, payload) {
-    if (typeof payload === 'boolean') {
-      state.addExamModal.visible = payload
-      return
+  setAddExamModalSetting(state, payload) {
+    console.log("setAddExamModalSetting==>>", payload);
+    if (typeof payload === "boolean") {
+      state.addExamModal.visible = payload;
+      return;
     }
     Object.keys(payload).forEach(key => {
-      Vue.set(state.addExamModal, key, payload[key])
-    })
+      console.log(key, "====>>>");
+      Vue.set(state.addExamModal, key, payload[key]);
+    });
   },
 
   resetAddExamModal: state => {
@@ -375,8 +375,8 @@ export const commonMutation: any = {
       setup: null,
       step1MenuOpen: false,
       office_number: null
-    }
-    state.addExamModule.candidates = []
+    };
+    state.addExamModule.candidates = [];
   },
 
   resetLogAnotherExamModal: (state, setup) => {
@@ -385,65 +385,65 @@ export const commonMutation: any = {
       setup: setup,
       step1MenuOpen: true,
       office_number: null
-    }
+    };
   },
 
-  toggleGenFinReport (state, payload) {
-    state.showGenFinReportModal = payload
+  toggleGenFinReport(state, payload) {
+    state.showGenFinReportModal = payload;
   },
 
-  captureExamDetail (state, payload) {
-    if (payload.key === 'exam_type_id') {
-      payload.value = Number(payload.value)
+  captureExamDetail(state, payload) {
+    if (payload.key === "exam_type_id") {
+      payload.value = Number(payload.value);
     }
-    if (payload.key === 'event_id') {
-      payload.value = payload.value.toString()
+    if (payload.key === "event_id") {
+      payload.value = payload.value.toString();
     }
     if (payload.value === null) {
-      payload.value = ''
+      payload.value = "";
     }
-    Vue.set(state.capturedExam, payload.key, payload.value)
+    Vue.set(state.capturedExam, payload.key, payload.value);
   },
 
-  resetCaptureForm (state) {
-    state.capturedExam = {}
-    state.addExamModule.candidates = []
-    state.captureITAExamTabSetup.capturePayee = false
-    state.captureITAExamTabSetup.payeeSentReceipt = false
-    state.examBcmpJobId = null
+  resetCaptureForm(state) {
+    state.capturedExam = {};
+    state.addExamModule.candidates = [];
+    state.captureITAExamTabSetup.capturePayee = false;
+    state.captureITAExamTabSetup.payeeSentReceipt = false;
+    state.examBcmpJobId = null;
   },
 
-  resetCaptureTab (state) {
+  resetCaptureTab(state) {
     Object.entries({
       step: 1,
       highestStep: 1,
       stepsValidated: [],
       errors: [],
       showRadio: true,
-      success: '',
+      success: "",
       notes: false
     }).forEach(entry => {
-      Vue.set(state.captureITAExamTabSetup, entry[0], entry[1])
-    })
+      Vue.set(state.captureITAExamTabSetup, entry[0], entry[1]);
+    });
   },
 
-  updateCaptureTab (state, payload) {
-    const keys = Object.keys(payload)
+  updateCaptureTab(state, payload) {
+    const keys = Object.keys(payload);
     keys.forEach(key => {
-      Vue.set(state.captureITAExamTabSetup, key, payload[key])
-    })
+      Vue.set(state.captureITAExamTabSetup, key, payload[key]);
+    });
   },
 
-  toggleIndividualCaptureTabRadio (state, payload) {
-    Vue.set(state.captureITAExamTabSetup, 'showRadio', payload)
+  toggleIndividualCaptureTabRadio(state, payload) {
+    Vue.set(state.captureITAExamTabSetup, "showRadio", payload);
   },
 
-  setBookings (state, payload) {
-    state.bookings = payload
+  setBookings(state, payload) {
+    state.bookings = payload;
   },
 
-  setRooms (state, payload) {
-    state.rooms = payload
+  setRooms(state, payload) {
+    state.rooms = payload;
   },
 
   toggleBookingModal: (state, payload) => (state.showBookingModal = payload),
@@ -453,8 +453,7 @@ export const commonMutation: any = {
   toggleExamInventoryModal: (state, payload) =>
     (state.showExamInventoryModal = payload),
 
-  toggleEditExamModal: (state, payload) =>
-    (state.showEditExamModal = payload),
+  toggleEditExamModal: (state, payload) => (state.showEditExamModal = payload),
 
   toggleSelectInvigilatorModal: (state, payload) =>
     (state.showSelectInvigilatorModal = payload),
@@ -465,21 +464,21 @@ export const commonMutation: any = {
   toggleDeleteExamModalVisible: (state, payload) =>
     (state.showDeleteExamModal = payload),
 
-  setSelectedExam (state, payload) {
-    if (payload === 'clearGoto') {
-      delete state.selectedExam.gotoDate
-      return
+  setSelectedExam(state, payload) {
+    if (payload === "clearGoto") {
+      delete state.selectedExam.gotoDate;
+      return;
     }
-    state.selectedExam = payload
+    state.selectedExam = payload;
   },
 
   toggleScheduling: (state, payload) => {
     if (!payload) {
-      state.scheduling = payload
-      state.rescheduling = payload
-      return
+      state.scheduling = payload;
+      state.rescheduling = payload;
+      return;
     }
-    state.scheduling = payload
+    state.scheduling = payload;
   },
 
   setCalendarSetup: (state, payload) => (state.calendarSetup = payload),
@@ -502,13 +501,13 @@ export const commonMutation: any = {
   toggleApptEditMode: (state, payload) =>
     (state.isAppointmentEditMode = payload),
 
-  setEditedBooking (state, payload) {
-    if (typeof payload === 'object' && payload !== null) {
-      state.editedBooking = Object.assign({}, payload)
+  setEditedBooking(state, payload) {
+    if (typeof payload === "object" && payload !== null) {
+      state.editedBooking = Object.assign({}, payload);
     }
     if (!payload) {
-      state.editedBooking = null
-      state.editedBookingOriginal = null
+      state.editedBooking = null;
+      state.editedBookingOriginal = null;
     }
   },
 
@@ -531,16 +530,16 @@ export const commonMutation: any = {
 
   setEvents: (state, payload) => (state.calendarEvents = payload),
 
-  setInventoryEditedBooking (state, booking) {
-    const bookingCopy = Object.assign({}, booking)
-    state.editedBooking = bookingCopy
+  setInventoryEditedBooking(state, booking) {
+    const bookingCopy = Object.assign({}, booking);
+    state.editedBooking = bookingCopy;
   },
 
   toggleEditGroupBookingModal: (state, payload) =>
     (state.showEditGroupBookingModal = payload),
 
-  setInventoryFilters (state, payload) {
-    state.inventoryFilters[payload.type] = payload.value
+  setInventoryFilters(state, payload) {
+    state.inventoryFilters[payload.type] = payload.value;
   },
 
   setSelectedExamType: (state, payload) => (state.selectedExamType = payload),
@@ -554,43 +553,43 @@ export const commonMutation: any = {
   setSelectedQuickActionFilter: (state, payload) =>
     (state.selectedQuickActionFilter = payload),
 
-  restoreSavedModal (state, payload) {
+  restoreSavedModal(state, payload) {
     Object.keys(payload.item).forEach(key => {
-      Vue.set(state[payload.name], key, payload.item[key])
-    })
+      Vue.set(state[payload.name], key, payload.item[key]);
+    });
   },
 
   toggleOffsiteVisible: (state, payload) => (state.offsiteVisible = payload),
 
-  toggleExamsTrackingIP: (state, payload) =>
-    (state.examsTrackingIP = payload),
+  toggleExamsTrackingIP: (state, payload) => (state.examsTrackingIP = payload),
 
   setAppointmentsStateInfo: (state, payload) =>
     (state.appointmentsStateInfo = payload),
 
   clearAddExamModalFromCalendarStatus: state =>
-    Vue.delete(state.addExamModal, 'fromCalendar'),
+    Vue.delete(state.addExamModal, "fromCalendar"),
 
-  toggleServeCitizenSpinner (state, payload) {
-    state.showServeCitizenSpinner = payload
+  toggleServeCitizenSpinner(state, payload) {
+    state.showServeCitizenSpinner = payload;
   },
-  toggleInviteCitizenSpinner (state, payload) {
-    state.showInviteCitizenSpinner = payload
+  toggleInviteCitizenSpinner(state, payload) {
+    state.showInviteCitizenSpinner = payload;
   },
 
   setOffsiteOnly: (state, payload) => (state.offsiteOnly = payload),
-  
-  setOfficeSwitcher: (state: StateModelIF, payload: boolean) => (state.showOfficeSwitcher = payload),
+
+  setOfficeSwitcher: (state: StateModelIF, payload: boolean) =>
+    (state.showOfficeSwitcher = payload),
 
   toggleTimeTrackingIcon: (state, payload) =>
     (state.showTimeTrackingIcon = payload),
 
-  deleteCapturedExamKey (state, payload) {
-    Vue.delete(state.capturedExam, payload)
+  deleteCapturedExamKey(state, payload) {
+    Vue.delete(state.capturedExam, payload);
   },
 
   setBCMPJobId: (state, payload) => {
-    state.capturedExam.bcmp_job_id = payload
-    state.examBcmpJobId = payload
-  },
-}
+    state.capturedExam.bcmp_job_id = payload;
+    state.examBcmpJobId = payload;
+  }
+};

--- a/frontend/src/store/mutations/mutations-model.ts
+++ b/frontend/src/store/mutations/mutations-model.ts
@@ -358,13 +358,11 @@ export const commonMutation: any = {
   setNavigation: (state, value) => (state.adminNavigation = value),
 
   setAddExamModalSetting(state, payload) {
-    console.log("setAddExamModalSetting==>>", payload);
     if (typeof payload === "boolean") {
       state.addExamModal.visible = payload;
       return;
     }
     Object.keys(payload).forEach(key => {
-      console.log(key, "====>>>");
       Vue.set(state.addExamModal, key, payload[key]);
     });
   },


### PR DESCRIPTION
vue, vuetify, sass, vue-template-compiler version degraded- add other exam and ENV exam fix

Note:
1. updated `sass@~1.32` because of `https://github.com/vuetifyjs/vuetify/issues/13694` warning