### PR TITLE
Provide a way to set the Gunicorn worker process timeout

### DIFF
--- a/jobs/appointment_reminder/send_sms_reminder.py
+++ b/jobs/appointment_reminder/send_sms_reminder.py
@@ -17,7 +17,7 @@ This module is being invoked from a job and it sends SMS reminders to customers.
 """
 import json
 import os
-
+import time
 import requests
 from flask import Flask
 
@@ -84,6 +84,7 @@ def send_reminders(app):
                                                   'Authorization': f'Bearer {token}'},
                                          data=json.dumps(notifications))
                 print(response)
+                time.sleep(5)
             except Exception as e:
                 print(e)  # log and continue
 

--- a/jobs/appointment_reminder/send_sms_reminder.py
+++ b/jobs/appointment_reminder/send_sms_reminder.py
@@ -17,7 +17,7 @@ This module is being invoked from a job and it sends SMS reminders to customers.
 """
 import json
 import os
-import time
+
 import requests
 from flask import Flask
 
@@ -84,7 +84,6 @@ def send_reminders(app):
                                                   'Authorization': f'Bearer {token}'},
                                          data=json.dumps(notifications))
                 print(response)
-                time.sleep(5)
             except Exception as e:
                 print(e)  # log and continue
 

--- a/notifications-api/gunicorn_config.py
+++ b/notifications-api/gunicorn_config.py
@@ -20,6 +20,7 @@ import os
 
 workers = int(os.environ.get('GUNICORN_PROCESSES', '1'))  # pylint: disable=invalid-name
 threads = int(os.environ.get('GUNICORN_THREADS', '1'))  # pylint: disable=invalid-name
+timeout = int(os.environ.get('GUNICORN_TIMEOUT', '30'))  # pylint: disable=invalid-name
 
 forwarded_allow_ips = '*'  # pylint: disable=invalid-name
 secure_scheme_headers = {'X-Forwarded-Proto': 'https'}  # pylint: disable=invalid-name

--- a/openshift/templates/notifications-api-dc.yml
+++ b/openshift/templates/notifications-api-dc.yml
@@ -67,6 +67,8 @@ objects:
               env:
                 - name: APP_CONFIG
                   value: gunicorn_config.py
+                - name: GUNICORN_TIMEOUT
+                  value: "${GUNICORN_TIMEOUT}"
                 - name: FLASK_ENV
                   value: "${FLASK_ENV}"
                 - name: APP_MODULE
@@ -194,6 +196,10 @@ parameters:
     description: "The configuration object that should be loaded for this deployment."
     required: true
     value: "production"
+  - name: GUNICORN_TIMEOUT
+    description: "The timeout in seconds for the gunicorn worker process"
+    required: true
+    value: "30"
   - name: API_IMAGE_TAG
     description: "The tag to use when deploying"
     required: true


### PR DESCRIPTION
We are having the worker process shut down after thirty seconds when the SMS job runs. Provide an environment variable that we can use to change the default timeout.