### PR TITLE
Change SMS reminders to use multiple API POSTs

### DIFF
--- a/jobs/appointment_reminder/send_sms_reminder.py
+++ b/jobs/appointment_reminder/send_sms_reminder.py
@@ -67,22 +67,20 @@ def send_reminders(app):
         appointments = reminders.json()
         notifications_endpoint = app.config.get('NOTIFICATIONS_ENDPOINT')
         token: str = get_access_token(app)
-        notifications = []
         for appointment in appointments.get('appointments'):
-            notifications.append({
+            notification = [{
                 'user_telephone': appointment.get('user_telephone'),
                 'display_name': appointment.get('display_name'),
                 'location': appointment.get('location'),
                 'formatted_date': appointment.get('formatted_date'),
                 'office_telephone': appointment.get('telephone')
-            })
+            }]
 
-        if notifications:
             try:
                 response = requests.post(notifications_endpoint,
                                          headers={'Content-Type': 'application/json',
                                                   'Authorization': f'Bearer {token}'},
-                                         data=json.dumps(notifications))
+                                         data=json.dumps(notification))
                 print(response)
             except Exception as e:
                 print(e)  # log and continue


### PR DESCRIPTION
Bug: SMS reminders were overloading the notification API pod. The SMS cron job was sending one huge POST with all the appointments in it. This put all the load on one API pod, and kept it so busy that it couldn't respond to health checks.

Fix: make a POST call to the notification API for each appointment. This will allow load balancing of the requests over all available API pods.