### PR TITLE
Fixing a CSS Bug in frontend

### DIFF
--- a/frontend/src/components/Appointments/buttons-appointments.vue
+++ b/frontend/src/components/Appointments/buttons-appointments.vue
@@ -26,7 +26,7 @@
     </b-button>
         </form>
       </div>
-      <div class="align-center">
+      <div class="align-center-text">
         <span class="q-inline-title">
           {{ calendar_setup.title }}
           {{ calendar_setup.titleRef && calendar_setup.titleRef.title }}
@@ -131,13 +131,10 @@ export default class ButtonsAppointments extends Vue {
 }
 </script>
 <style scoped>
-.align-center {
+.align-center-text {
   padding-left: 40%;
   margin-top: -46px;
 }​
-.butttons-appointments {
-  margin-right: auto;
-}
 .full-div {
   width: 100%;
 }


### PR DESCRIPTION
We're unsure what's causing SQ to flag this as a bug, so here's hoping this change fixes it.

I renamed "align-center" to "align-center-text" and removed an unused portion of the CSS.