### PR TITLE
Actions master deploy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# As a security feature, add these people as reviewers if a PR is created for
+# anything under .github, including GitHub Actions and this file itself.
+.github/ @jhmccoll @josekudiyirippil @gil0109

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,6 +10,15 @@ The GitHub Action `pull-request-deploy.yaml` is only run manually. It will:
 - Run OWASP ZAP tests
 - Run Newman tests if the deployment environment is The Q dev
 
+The GitHub Action `master-deploy.yaml` is only run manually. It will:
+
+- Build images using either Dockerfile or Source to Image (S2I) builds
+- Push the built images to two different `-tools` namespaces
+- Use GitHub `environments` to define approvers for tagging images to `-dev`, `-test`, and `-prod` namespaces
+- Run `oc tag` to tag the images in the two `-tools` namespaces for `dev`, then `test`, and then `prod` tags
+- After deployment to The Q dev, wait for rollout of the new images
+- After deployment to The Q dev, run Newman and OWASP ZAP tests
+
 ## Setup
 
 The following setup items are needed to run the Actions.
@@ -87,8 +96,19 @@ There are many GitHub Secrets that are needed to run the Actions:
 
 (note: there is a script to set these up automatically, but it can't be committed)
 
+## Third-Party Actions
+
+The following actions are being used:
+
+- [actions/checkout](https://github.com/actions/checkout): checks the code out of the GitHub repository
+- [actions/upload-artifact](https://github.com/actions/upload-artifact): uploads the OWASP ZAP scan artifacts
+- [redhat-actions/buildah-build](https://github.com/redhat-actions/buildah-build): builds using a Dockerfile
+- [redhat-actions/oc-login](https://github.com/redhat-actions/oc-login): logs into OpenShift using `oc`
+- [redhat-actions/podman-login](https://github.com/redhat-actions/podman-login): logs into Artifactory to be able to pull images for builds
+- [redhat-actions/push-to-registry](https://github.com/redhat-actions/push-to-registry): pushes built images into the tools namespaces
+- [redhat-actions/s2i-build](https://github.com/redhat-actions/s2i-build): builds using Source to Image (S2I)
+- [zaproxy/action-full-scan](https://github.com/zaproxy/action-full-scan): runs an OWASP ZAP scan against the Staff Frontend and the Appointment Frontend
+
 ## Notes
 - The Artifacts aren't visible until after the workflow has completed running. It would be ideal if they were available as soon as the tests finish running. On the other hand, on test failure they should be immediately available and perhaps this is good enough? Details here: https://github.com/actions/upload-artifact/issues/53
-
-## Enhancements Backlog
-1. Delete the OWASP ZAP artifact `zap_scan` - using the API doesn't work as the Artifact hasn't been marked as `complete` yet, so the GET API call won't get the Artifact.
+- There is an artifact called `zap-scan` that is created and should be ignored. Waiting on an enhancement from ZAP so that we can specify the name of the Artifact: https://github.com/zaproxy/action-baseline/issues/45

--- a/.github/workflows/master-deploy.yaml
+++ b/.github/workflows/master-deploy.yaml
@@ -1,71 +1,16 @@
-name: Pull Request Deploy
+name: Master Deploy
+concurrency: 
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 on:
   workflow_dispatch:
-    inputs:
-      pr-number:
-        description: "Pull Request Number:"
-        type: string
-        required: true
-      namespace:
-        description: "Deploy To:"
-        type: choice
-        required: true
-        options:
-        - The Q Dev
-        - QMS Dev
-        - The Q Test
 
 jobs:
-
-  ##### SETUP ##################################################################
-
-  parse-inputs:
-    name: refs/pull/${{ github.event.inputs.pr-number }}/head to ${{ github.event.inputs.namespace }}
-    runs-on: ubuntu-latest
-    outputs:
-      environment: ${{ steps.parse.outputs.environment }}
-      image-tag: ${{ steps.parse.outputs.image-tag }}
-      push-qms: ${{ steps.parse.outputs.push-qms }}
-      push-theq: ${{ steps.parse.outputs.push-theq }}
-      ref: ${{ steps.parse.outputs.ref }}
-
-    steps:
-    # Use the input values to create more coding-friendly values.
-    - name: Parse Inputs
-      id: parse
-      run: |
-        # Gets "dev" or "test".
-        ENVIRONMENT=$(echo ${{ github.event.inputs.namespace }} | awk -F' ' '{print $NF}' | tr '[:upper:]' '[:lower:]')
-        echo ENVIRONMENT:$ENVIRONMENT
-        echo "::set-output name=environment::$ENVIRONMENT"
-
-        IMAGE_TAG=pr${{ github.event.inputs.pr-number }}
-        echo IMAGE_TAG:$IMAGE_TAG
-        echo "::set-output name=image-tag::$IMAGE_TAG"
-
-        if [[ "${{ github.event.inputs.namespace }}" == QMS* ]]; then
-          PUSH_QMS=true
-          PUSH_THEQ=false
-        else
-          PUSH_QMS=false
-          PUSH_THEQ=true
-        fi
-
-        echo PUSH_QMS:$PUSH_QMS
-        echo "::set-output name=push-qms::$PUSH_QMS"
-
-        echo PUSH_THEQ:$PUSH_THEQ
-        echo "::set-output name=push-theq::$PUSH_THEQ"
-
-        REF=refs/pull/${{ github.event.inputs.pr-number }}/head
-        echo REF:$REF
-        echo "::set-output name=ref::$REF"
 
   ##### BUILD ##################################################################
 
   appointment-frontend:
     name: appointment-frontend
-    needs: parse-inputs
     uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -79,16 +24,12 @@ jobs:
       namespace-qms-username: ${{ secrets.SA_USERNAME }}
       openshift-registry: ${{ secrets.OPENSHIFT_REGISTRY }}
     with:
-      ref: ${{ needs.parse-inputs.outputs.ref }}
       directory: appointment-frontend
       image-name: appointment-nginx-frontend
-      image-tags: ${{ needs.parse-inputs.outputs.image-tag }}
-      push-qms: ${{ needs.parse-inputs.outputs.push-qms == 'true' }}
-      push-theq: ${{ needs.parse-inputs.outputs.push-theq == 'true' }}
+      image-tags: commit-${GITHUB_SHA::7} latest
 
   feedback-api:
     name: feedback-api
-    needs: parse-inputs
     uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
@@ -99,16 +40,12 @@ jobs:
       namespace-qms-username: ${{ secrets.SA_USERNAME }}
       openshift-registry: ${{ secrets.OPENSHIFT_REGISTRY }}
     with:
-      ref: ${{ needs.parse-inputs.outputs.ref }}
       directory: feedback-api
       image-name: feedback-api
-      image-tags: ${{ needs.parse-inputs.outputs.image-tag }}
-      push-qms: ${{ needs.parse-inputs.outputs.push-qms == 'true' }}
-      push-theq: ${{ needs.parse-inputs.outputs.push-theq == 'true' }}
+      image-tags: commit-${GITHUB_SHA::7} latest
 
   notifications-api:
     name: notifications-api
-    needs: parse-inputs
     uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
@@ -119,16 +56,12 @@ jobs:
       namespace-qms-username: ${{ secrets.SA_USERNAME }}
       openshift-registry: ${{ secrets.OPENSHIFT_REGISTRY }}
     with:
-      ref: ${{ needs.parse-inputs.outputs.ref }}
       directory: notifications-api
       image-name: notifications-api
-      image-tags: ${{ needs.parse-inputs.outputs.image-tag }}
-      push-qms: ${{ needs.parse-inputs.outputs.push-qms == 'true' }}
-      push-theq: ${{ needs.parse-inputs.outputs.push-theq == 'true' }}
+      image-tags: commit-${GITHUB_SHA::7} latest
 
   queue-management-api:
     name: queue-management-api
-    needs: parse-inputs
     uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -142,16 +75,12 @@ jobs:
       namespace-qms-username: ${{ secrets.SA_USERNAME }}
       openshift-registry: ${{ secrets.OPENSHIFT_REGISTRY }}
     with:
-      ref: ${{ needs.parse-inputs.outputs.ref }}
       directory: api
       image-name: queue-management-api
-      image-tags: ${{ needs.parse-inputs.outputs.image-tag }}
-      push-qms: ${{ needs.parse-inputs.outputs.push-qms == 'true' }}
-      push-theq: ${{ needs.parse-inputs.outputs.push-theq == 'true' }}
+      image-tags: commit-${GITHUB_SHA::7} latest
 
   queue-management-frontend:
     name: queue-management-frontend
-    needs: parse-inputs
     uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -165,16 +94,12 @@ jobs:
       namespace-qms-username: ${{ secrets.SA_USERNAME }}
       openshift-registry: ${{ secrets.OPENSHIFT_REGISTRY }}
     with:
-      ref: ${{ needs.parse-inputs.outputs.ref }}
       directory: frontend
       image-name: queue-management-nginx-frontend
-      image-tags: ${{ needs.parse-inputs.outputs.image-tag }}
-      push-qms: ${{ needs.parse-inputs.outputs.push-qms == 'true' }}
-      push-theq: ${{ needs.parse-inputs.outputs.push-theq == 'true' }}
+      image-tags: commit-${GITHUB_SHA::7} latest
 
   send-appointment-reminder-crond:
     name: send-appointment-reminder-crond
-    needs: parse-inputs
     uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -188,47 +113,50 @@ jobs:
       namespace-qms-username: ${{ secrets.SA_USERNAME }}
       openshift-registry: ${{ secrets.OPENSHIFT_REGISTRY }}
     with:
-      ref: ${{ needs.parse-inputs.outputs.ref }}
       directory: jobs/appointment_reminder
       image-name: send-appointment-reminder-crond
-      image-tags: ${{ needs.parse-inputs.outputs.image-tag }}
-      push-qms: ${{ needs.parse-inputs.outputs.push-qms == 'true' }}
-      push-theq: ${{ needs.parse-inputs.outputs.push-theq == 'true' }}
+      image-tags: commit-${GITHUB_SHA::7} latest
 
-  ##### DEPLOY #################################################################
+  ##### DEPLOY THE Q ###########################################################
 
-  tag:
-    name: Tag
-    needs: [parse-inputs, appointment-frontend, feedback-api, notifications-api, queue-management-api, queue-management-frontend, send-appointment-reminder-crond]
+  approve-theq-dev:
+    name: Approve Deploy to The Q Dev
+    needs: [appointment-frontend, feedback-api, notifications-api, queue-management-api, queue-management-frontend, send-appointment-reminder-crond]
+    environment: The Q Dev
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deployment Approval
+        run: echo Approved
+
+  tag-theq-dev:
+    name: Tag The Q Dev
+    needs: approve-theq-dev
     uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
     secrets:
-      licence-plate: ${{ needs.parse-inputs.outputs.push-qms == 'true' && secrets.LICENCE_PLATE_QMS || secrets.LICENCE_PLATE_THEQ }}
+      licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
-      token: ${{ needs.parse-inputs.outputs.push-qms == 'true' && secrets.SA_PASSWORD_QMS_TOOLS || secrets.SA_PASSWORD_THEQ_TOOLS }}
+      token: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
     with:
       image-names: appointment-nginx-frontend feedback-api notifications-api queue-management-api queue-management-nginx-frontend send-appointment-reminder-crond
-      tag-from: ${{ needs.parse-inputs.outputs.image-tag }}
-      tag-to: ${{ needs.parse-inputs.outputs.environment }}
+      tag-from: commit-${GITHUB_SHA::7}
+      tag-to: dev
 
   wait-for-rollouts:
     name: Wait for Rollouts
-    needs: [parse-inputs, tag]
+    needs: tag-theq-dev
     uses: bcgov/queue-management/.github/workflows/reusable-wait-for-rollouts.yaml@master
     secrets:
-      licence-plate: ${{ needs.parse-inputs.outputs.push-qms == 'true' && secrets.LICENCE_PLATE_QMS || secrets.LICENCE_PLATE_THEQ }}
+      licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
-      token: ${{ needs.parse-inputs.outputs.push-qms == 'true' && secrets.SA_PASSWORD_QMS_DEV || ( needs.parse-inputs.outputs.environment == 'dev' && secrets.SA_PASSWORD_THEQ_DEV || secrets.SA_PASSWORD_THEQ_TEST ) }}
+      token: ${{ secrets.SA_PASSWORD_THEQ_DEV }}
     with:
-      image-names: appointment-nginx-frontend feedback-api notifications-api queue-management-api queue-management-nginx-frontend send-appointment-reminder-crond-${{ needs.parse-inputs.outputs.environment }}
-      tag-to: ${{ needs.parse-inputs.outputs.environment }}
+      image-names: appointment-nginx-frontend feedback-api notifications-api queue-management-api queue-management-nginx-frontend send-appointment-reminder-crond-dev
+      tag-to: dev
 
-  ##### TEST ###################################################################
-
-  # Only run Newman for The Q dev - other environments will fail due to data.
-  newman-theq-dev:
-    name: Newman Tests
-    if: github.event.inputs.namespace == 'The Q Dev'
-    needs: [parse-inputs, wait-for-rollouts]
+  newman-theq:
+    name: Newman Tests in The Q Dev
+    needs: wait-for-rollouts
     runs-on: ubuntu-latest
 
     steps:
@@ -239,7 +167,6 @@ jobs:
       run: |
         cd api/postman
         npm install newman
-
     - name: Run Newman Tests
       run: |
         cd api/postman
@@ -258,28 +185,17 @@ jobs:
           --global-var 'url=${{ secrets.POSTMAN_API_URL_THEQ_DEV }}' \
           --global-var 'userid=${{ secrets.POSTMAN_USERID }}' \
           --global-var 'userid_nonqtxn=${{ secrets.POSTMAN_USERID_NONQTXN }}'
-
   owasp-staff:
     name: OWASP ZAP Scan of Staff Frontend
-    needs: [parse-inputs, wait-for-rollouts]
+    needs: wait-for-rollouts
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get Parameters
-        run: |
-          if [ ${{ needs.parse-inputs.outputs.push-qms }} == true ]; then
-            echo "ZAP_URL=${{ secrets.ZAP_STAFFURL_QMS_DEV }}" >> $GITHUB_ENV
-          elif [ ${{ needs.parse-inputs.outputs.environment }} == dev ]; then
-            echo "ZAP_URL=${{ secrets.ZAP_STAFFURL_THEQ_DEV }}" >> $GITHUB_ENV
-          else
-            echo "ZAP_URL=${{ secrets.ZAP_STAFFURL_THEQ_TEST }}" >> $GITHUB_ENV
-          fi
-
       - name: OWASP ZAP Scan
         uses: zaproxy/action-full-scan@v0.3.0
         with:
           allow_issue_writing: false
-          target: ${{ env.ZAP_URL }}
+          target: ${{ secrets.ZAP_STAFFURL_THEQ_DEV  }}
 
       - name: Upload Report as Artifact
         uses: actions/upload-artifact@v3
@@ -289,28 +205,161 @@ jobs:
 
   owasp-appointment:
     name: OWASP ZAP Scan of Appointment Frontend
-    needs: [parse-inputs, wait-for-rollouts]
+    needs: wait-for-rollouts
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get Parameters
-        run: |
-          if [ ${{ needs.parse-inputs.outputs.push-qms }} == true ]; then
-            echo "ZAP_URL=${{ secrets.ZAP_APPTMNTURL_QMS_DEV }}" >> $GITHUB_ENV
-          elif [ ${{ needs.parse-inputs.outputs.environment }} == dev ]; then
-            echo "ZAP_URL=${{ secrets.ZAP_APPTMNTURL_THEQ_DEV }}" >> $GITHUB_ENV
-          else
-            echo "ZAP_URL=${{ secrets.ZAP_APPTMNTURL_THEQ_TEST }}" >> $GITHUB_ENV
-          fi
-
       - name: OWASP ZAP Scan
         uses: zaproxy/action-full-scan@v0.3.0
         with:
           allow_issue_writing: false
-          target: ${{ env.ZAP_URL }}
+          target: ${{ secrets.ZAP_APPTMNTURL_THEQ_DEV  }}
 
       - name: Upload Report as Artifact
         uses: actions/upload-artifact@v3
         with:
           name: OWASP ZAP - Appointment Front End Report
           path: report_html.html
+
+  approve-theq-test:
+    name: Approve Deploy to The Q Test
+    needs: [newman-theq, owasp-staff, owasp-appointment]
+    environment: The Q Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deployment Approval
+        run: echo Approved
+
+  tag-theq-test:
+    name: Tag The Q Test
+    needs: approve-theq-test
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    secrets:
+      licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
+      openshift-api: ${{ secrets.OPENSHIFT_API }}
+      token: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
+    with:
+      image-names: appointment-nginx-frontend feedback-api notifications-api queue-management-api queue-management-nginx-frontend send-appointment-reminder-crond
+      tag-from: commit-${GITHUB_SHA::7}
+      tag-to: test
+
+  approve-theq-prod:
+    name: Approve Deploy to The Q Prod
+    needs: tag-theq-test
+    environment: The Q Prod
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deployment Approval
+        run: echo Approved
+
+  tag-theq-stable:
+    name: Tag The Q Stable
+    needs: approve-theq-prod
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    secrets:
+      licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
+      openshift-api: ${{ secrets.OPENSHIFT_API }}
+      token: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
+    with:
+      image-names: appointment-nginx-frontend feedback-api notifications-api queue-management-api queue-management-nginx-frontend send-appointment-reminder-crond
+      tag-from: prod
+      tag-to: stable
+
+  tag-theq-prod:
+    name: Tag The Q Prod
+    needs: tag-theq-stable
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    secrets:
+      licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
+      openshift-api: ${{ secrets.OPENSHIFT_API }}
+      token: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
+    with:
+      image-names: appointment-nginx-frontend feedback-api notifications-api queue-management-api queue-management-nginx-frontend send-appointment-reminder-crond
+      tag-from: commit-${GITHUB_SHA::7}
+      tag-to: prod
+
+  ##### DEPLOY QMS #############################################################
+
+  approve-qms-dev:
+    name: Approve Deploy to QMS Dev
+    needs: [appointment-frontend, feedback-api, notifications-api, queue-management-api, queue-management-frontend, send-appointment-reminder-crond]
+    environment: QMS Dev
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deployment Approval
+        run: echo Approved
+
+  tag-qms-dev:
+    name: Tag QMS Dev
+    needs: approve-qms-dev
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    secrets:
+      licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
+      openshift-api: ${{ secrets.OPENSHIFT_API }}
+      token: ${{ secrets.SA_PASSWORD_QMS_TOOLS }}
+    with:
+      image-names: appointment-nginx-frontend feedback-api notifications-api queue-management-api queue-management-nginx-frontend send-appointment-reminder-crond
+      tag-from: commit-${GITHUB_SHA::7}
+      tag-to: dev
+
+  approve-qms-test:
+    name: Approve Deploy to QMS Test
+    needs: tag-qms-dev
+    environment: QMS Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deployment Approval
+        run: echo Approved
+
+  tag-qms-test:
+    name: Tag QMS Test
+    needs: approve-qms-test
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    secrets:
+      licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
+      openshift-api: ${{ secrets.OPENSHIFT_API }}
+      token: ${{ secrets.SA_PASSWORD_QMS_TOOLS }}
+    with:
+      image-names: appointment-nginx-frontend feedback-api notifications-api queue-management-api queue-management-nginx-frontend send-appointment-reminder-crond
+      tag-from: commit-${GITHUB_SHA::7}
+      tag-to: test
+
+  approve-qms-prod:
+    name: Approve Deploy to QMS Prod
+    needs: tag-qms-test
+    environment: QMS Prod
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deployment Approval
+        run: echo Approved
+
+  tag-qms-stable:
+    name: Tag QMS Stable
+    needs: approve-qms-prod
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    secrets:
+      licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
+      openshift-api: ${{ secrets.OPENSHIFT_API }}
+      token: ${{ secrets.SA_PASSWORD_QMS_TOOLS }}
+    with:
+      image-names: appointment-nginx-frontend feedback-api notifications-api queue-management-api queue-management-nginx-frontend send-appointment-reminder-crond
+      tag-from: prod
+      tag-to: stable
+
+  tag-qms-prod:
+    name: Tag QMS Prod
+    needs: tag-qms-stable
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    secrets:
+      licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
+      openshift-api: ${{ secrets.OPENSHIFT_API }}
+      token: ${{ secrets.SA_PASSWORD_QMS_TOOLS }}
+    with:
+      image-names: appointment-nginx-frontend feedback-api notifications-api queue-management-api queue-management-nginx-frontend send-appointment-reminder-crond
+      tag-from: commit-${GITHUB_SHA::7}
+      tag-to: prod

--- a/.github/workflows/master-deploy.yaml
+++ b/.github/workflows/master-deploy.yaml
@@ -167,6 +167,7 @@ jobs:
       run: |
         cd api/postman
         npm install newman
+
     - name: Run Newman Tests
       run: |
         cd api/postman
@@ -196,6 +197,7 @@ jobs:
         uses: zaproxy/action-full-scan@v0.3.0
         with:
           allow_issue_writing: false
+          cmd_options: '-z "-config scanner.threadPerHost=20"'
           target: ${{ secrets.ZAP_STAFFURL_THEQ_DEV  }}
 
       - name: Upload Report as Artifact
@@ -214,6 +216,7 @@ jobs:
         uses: zaproxy/action-full-scan@v0.3.0
         with:
           allow_issue_writing: false
+          cmd_options: '-z "-config scanner.threadPerHost=20"'
           target: ${{ secrets.ZAP_APPTMNTURL_THEQ_DEV  }}
 
       - name: Upload Report as Artifact

--- a/.github/workflows/master-deploy.yaml
+++ b/.github/workflows/master-deploy.yaml
@@ -185,6 +185,7 @@ jobs:
           --global-var 'url=${{ secrets.POSTMAN_API_URL_THEQ_DEV }}' \
           --global-var 'userid=${{ secrets.POSTMAN_USERID }}' \
           --global-var 'userid_nonqtxn=${{ secrets.POSTMAN_USERID_NONQTXN }}'
+
   owasp-staff:
     name: OWASP ZAP Scan of Staff Frontend
     needs: wait-for-rollouts

--- a/.github/workflows/openshift/service_account.yaml
+++ b/.github/workflows/openshift/service_account.yaml
@@ -1,0 +1,53 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: github-actions
+objects:
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: Role
+  metadata:
+    name: github-actions
+  rules:
+  - apiGroups:
+      - ''
+    resources:
+      - replicationcontrollers
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apps.openshift.io
+    resources:
+      - deploymentconfigs
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreams
+      - imagestreams/layers
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreams
+    verbs:
+      - create
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: RoleBinding
+  metadata:
+    name: github-actions
+  subjects:
+    - kind: ServiceAccount
+      name: github-actions
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: github-actions
+- apiVersion: v1
+  kind: ServiceAccount
+  metadata:
+    name: github-actions

--- a/.github/workflows/pull-request-deploy.yaml
+++ b/.github/workflows/pull-request-deploy.yaml
@@ -279,6 +279,7 @@ jobs:
         uses: zaproxy/action-full-scan@v0.3.0
         with:
           allow_issue_writing: false
+          cmd_options: '-z "-config scanner.threadPerHost=20"'
           target: ${{ env.ZAP_URL }}
 
       - name: Upload Report as Artifact
@@ -307,6 +308,7 @@ jobs:
         uses: zaproxy/action-full-scan@v0.3.0
         with:
           allow_issue_writing: false
+          cmd_options: '-z "-config scanner.threadPerHost=20"'
           target: ${{ env.ZAP_URL }}
 
       - name: Upload Report as Artifact

--- a/.github/workflows/reusable-build-dockerfile.yaml
+++ b/.github/workflows/reusable-build-dockerfile.yaml
@@ -44,18 +44,22 @@ on:
         required: true
       openshift-registry:
         required: true
-    outputs:
-      image-tags:
-        value: ${{ jobs.build.outputs.image-tags }}
 
 jobs:
   build:
     name: Dockerfile Build
     runs-on: ubuntu-latest
-    outputs:
-      image-tags: ${{ steps.build-image.outputs.tags }}
 
     steps:
+    - name: Process Image Tags
+      run: |
+        # This is a little strange - we can put bash processing in an input
+        # parameter, such as "${GITHUB_SHA::7}". It will come in as that exact
+        # string, so we need to echo it in bash to process it into the string
+        # that we actually want.
+        echo '${{ inputs.image-tags }} =>' ${{ inputs.image-tags }}
+        echo "IMAGE_TAGS=${{ inputs.image-tags }}" >> $GITHUB_ENV
+
     - name: Check out
       uses: actions/checkout@v2
       with:
@@ -83,7 +87,7 @@ jobs:
         containerfiles: ${{ inputs.directory }}/Dockerfile
         context: ${{ inputs.directory }}
         image: ${{ inputs.image-name }}
-        tags: ${{ inputs.image-tags }}
+        tags: ${{ env.IMAGE_TAGS }}
 
     - name: Debug for errors
       run: cd /var/tmp; df -h .

--- a/.github/workflows/reusable-build-s2i.yaml
+++ b/.github/workflows/reusable-build-s2i.yaml
@@ -44,18 +44,22 @@ on:
         required: true
       openshift-registry:
         required: true
-    outputs:
-      image-tags:
-        value: ${{ jobs.build.outputs.image-tags }}
 
 jobs:
   build:
     name: S2I Build
     runs-on: ubuntu-latest
-    outputs:
-      image-tags: ${{ steps.build-image.outputs.tags }}
 
     steps:
+    - name: Process Image Tags
+      run: |
+        # This is a little strange - we can put bash processing in an input
+        # parameter, such as "${GITHUB_SHA::7}". It will come in as that exact
+        # string, so we need to echo it in bash to process it into the string
+        # that we actually want.
+        echo '${{ inputs.image-tags }} =>' ${{ inputs.image-tags }}
+        echo "IMAGE_TAGS=${{ inputs.image-tags }}" >> $GITHUB_ENV
+
     - name: Check out
       uses: actions/checkout@v2
       with:
@@ -83,7 +87,7 @@ jobs:
           AF_PASSWD=${{ secrets.artifactory-password }}
         image: ${{ inputs.image-name }}
         path_context: ${{ inputs.directory }}
-        tags: ${{ inputs.image-tags }}
+        tags: ${{ env.IMAGE_TAGS }}
 
     - name: Debug - time before The Q
       run: date

--- a/.github/workflows/reusable-tag-image.yaml
+++ b/.github/workflows/reusable-tag-image.yaml
@@ -18,16 +18,11 @@ on:
         required: true
       token:
         required: true
-    outputs:
-      tag-from:
-        value: ${{ jobs.build.outputs.tag-from }}
 
 jobs:
   tag:
-    name: Tag from ${{ inputs.tag-from }} to ${{ inputs.tag-to }}
+    name: Tag to ${{ inputs.tag-to }}
     runs-on: ubuntu-latest
-    outputs:
-      tag-from: ${{ inputs.tag-from }}
 
     steps:
     - name: Log in to OpenShift tools


### PR DESCRIPTION
Added the new GitHub Action `master-deploy.yaml` to build from master and deploy to all environments.

Added changes:
- Added a CODEOWNERS file to help protect the GitHub Actions
- Updated the README with `master-deploy.yaml` information
- Updated the README with a list of all third party Actions that we are using
- Updated the README to mention the enhancement we are waiting on so that we can define the name of the ZAP artifact
- Added the `service-account.yaml` file that was forgotten in the previous pull request
- Set the names of the ZAP scans to be more informative and consistent
- Set up the ZAP scans to run with 20 threads (default 2) to decrease run time
- Remove the output values from reusable workflows as they are not being used