### PR TITLE
Added Cypress tests to GitHub Actions pipelines

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,8 @@
 The GitHub Action `pull-request-deploy.yaml` is only run manually. It will:
 
 - Take a pull request number and environment as input parameters
-- Build images using either Dockerfile or Source to Image (S2I) builds
+- Run Cypress tests against the Appointment Frontend
+- Build images using Dockerfile and Source to Image (S2I) builds
 - Push the built images to the required `-tools` namespace
 - Run `oc tag` to tag the images in the `-tools` namespace to `dev` (The Q or QMS) or `test` (The Q)
 - Wait for rollout of the new images in the deployment environment
@@ -12,7 +13,8 @@ The GitHub Action `pull-request-deploy.yaml` is only run manually. It will:
 
 The GitHub Action `master-deploy.yaml` is only run manually. It will:
 
-- Build images using either Dockerfile or Source to Image (S2I) builds
+- Run Cypress tests against the Appointment Frontend
+- Build images using Dockerfile and Source to Image (S2I) builds
 - Push the built images to two different `-tools` namespaces
 - Use GitHub `environments` to define approvers for tagging images to `-dev`, `-test`, and `-prod` namespaces
 - Run `oc tag` to tag the images in the two `-tools` namespaces for `dev`, then `test`, and then `prod` tags
@@ -50,7 +52,7 @@ The Service Account named `github-actions` needs to be set up in all the `-tools
 Using [the OpenShift template](openshift/service_account.yaml) run:
 
 ```
-$ oc process -f service-account.yaml | oc -n <namespace> apply -f -
+$ oc process -f service_account.yaml | oc -n <namespace> apply -f -
 ```
 
 ### GitHub Secrets
@@ -62,6 +64,14 @@ There are many GitHub Secrets that are needed to run the Actions:
 | ARTIFACTORY_PASSWORD | Some of the builds use Dockerfiles that pull images from Artifactory. This value comes from the `artifactory-creds` secret |
 | ARTIFACTORY_REGISTRY | Some of the builds use Dockerfiles that pull images from Artifactory. This value comes from the `artifactory-creds` secret |
 | ARTIFACTORY_USERNAME | Some of the builds use Dockerfiles that pull images from Artifactory. This value comes from the `artifactory-creds` secret |
+| CYPRESS_BCEID_ENDPOINT | The endpoint to log into BCeID for Cypress testing |
+| CYPRESS_BCEID_PASSWORD | The password to log into BCeID for Cypress testing |
+| CYPRESS_BCEID_USERNAME | The username to log into BCeID for Cypress testing |
+| CYPRESS_PROJECT_ID | The project ID used for the Cypress Dashboard |
+| CYPRESS_RECORD_KEY | The record key used for the Cypress Dashboard |
+| KEYCLOAK_APPOINTMENTS_FRONTEND_CLIENT | The Keycloak client that is used for the Appointment Frontend |
+| KEYCLOAK_AUTH_URL_DEV | The Keycloak URL for the development environment |
+| KEYCLOAK_REALM | The Keycloak realm |
 | LICENCE_PLATE_QMS | The six character "licence plate" prefix for the QMS namespaces |
 | LICENCE_PLATE_THEQ | The six character "licence plate" prefix for The Q namespaces |
 | OPENSHIFT_API | The URL of the OpenShift API used to make API calls |
@@ -79,13 +89,10 @@ There are many GitHub Secrets that are needed to run the Actions:
 | POSTMAN_USERID | The Username of the Keycloak user used to run The Q tests |
 | POSTMAN_USERID_NONQTXN | The Username of the Keycloak user used to run non-Q tests |
 | SA_PASSWORD_QMS_DEV | The token for the Service Account `github-actions` in the QMS dev namespace |
-| SA_PASSWORD_QMS_TEST | The token for the Service Account `github-actions` in the QMS test namespace |
 | SA_PASSWORD_QMS_TOOLS | The token for the Service Account `github-actions` in the QMS tools namespace |
-| SA_PASSWORD_QMS_PROD | The token for the Service Account `github-actions` in the QMS prod namespace |
 | SA_PASSWORD_THEQ_DEV | The token for the Service Account `github-actions` in The Q dev namespace |
 | SA_PASSWORD_THEQ_TEST | The token for the Service Account `github-actions` in The Q test namespace |
 | SA_PASSWORD_THEQ_TOOLS | The token for the Service Account `github-actions` in The Q tools namespace |
-| SA_PASSWORD_THEQ_PROD | The token for the Service Account `github-actions` in The Q prod namespace |
 | SA_USERNAME | The name of the Service Account: `github-actions` in namespaces |
 | ZAP_APPTMNTURL_QMS_DEV | The URL of the QMS dev Appointments application used for running the OWASP ZAP tests |
 | ZAP_APPTMNTURL_THEQ_DEV | The URL of The Q dev Appointments application used for running the OWASP ZAP tests |
@@ -94,14 +101,15 @@ There are many GitHub Secrets that are needed to run the Actions:
 | ZAP_STAFFURL_THEQ_DEV | The URL of The Q dev used for running the OWASP ZAP tests |
 | ZAP_STAFFURL_THEQ_TEST | The URL of The Q test used for running the OWASP ZAP tests |
 
-(note: there is a script to set these up automatically, but it can't be committed)
+(note: in OneNote there is a script to set these up automatically, but it can't be committed)
 
 ## Third-Party Actions
 
 The following actions are being used:
 
 - [actions/checkout](https://github.com/actions/checkout): checks the code out of the GitHub repository
-- [actions/upload-artifact](https://github.com/actions/upload-artifact): uploads the OWASP ZAP scan artifacts
+- [actions/upload-artifact](https://github.com/actions/upload-artifact): uploads the Cypress test and OWASP ZAP scan artifacts
+- [cypress-io/github-action](https://github.com/cypress-io/github-action): runs Cypress tests
 - [redhat-actions/buildah-build](https://github.com/redhat-actions/buildah-build): builds using a Dockerfile
 - [redhat-actions/oc-login](https://github.com/redhat-actions/oc-login): logs into OpenShift using `oc`
 - [redhat-actions/podman-login](https://github.com/redhat-actions/podman-login): logs into Artifactory to be able to pull images for builds

--- a/.github/workflows/master-deploy.yaml
+++ b/.github/workflows/master-deploy.yaml
@@ -7,10 +7,26 @@ on:
 
 jobs:
 
+  ##### TESTS ##################################################################
+
+  appointment-frontend-cypress:
+    name: Appointment Frontend Cypress
+    uses: bcgov/queue-management/.github/workflows/reusable-appointment-frontend-cypress.yaml@master
+    secrets:
+      bceid-endpoint: ${{ secrets.CYPRESS_BCEID_ENDPOINT }}
+      bceid-password: ${{ secrets.CYPRESS_BCEID_PASSWORD }}
+      bceid-username: ${{ secrets.CYPRESS_BCEID_USERNAME }}
+      cypress-project-id: ${{ secrets.CYPRESS_PROJECT_ID }}
+      cypress-record-key: ${{ secrets.CYPRESS_RECORD_KEY }}
+      keycloak-auth-url: ${{ secrets.KEYCLOAK_AUTH_URL_DEV }}/auth/
+      keycloak-client: ${{ secrets.KEYCLOAK_APPOINTMENTS_FRONTEND_CLIENT }}
+      keycloak-realm: ${{ secrets.KEYCLOAK_REALM }}
+
   ##### BUILD ##################################################################
 
   appointment-frontend:
     name: appointment-frontend
+    needs: appointment-frontend-cypress
     uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -30,6 +46,7 @@ jobs:
 
   feedback-api:
     name: feedback-api
+    needs: appointment-frontend-cypress
     uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
@@ -46,6 +63,7 @@ jobs:
 
   notifications-api:
     name: notifications-api
+    needs: appointment-frontend-cypress
     uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
@@ -62,6 +80,7 @@ jobs:
 
   queue-management-api:
     name: queue-management-api
+    needs: appointment-frontend-cypress
     uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -81,6 +100,7 @@ jobs:
 
   queue-management-frontend:
     name: queue-management-frontend
+    needs: appointment-frontend-cypress
     uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -100,6 +120,7 @@ jobs:
 
   send-appointment-reminder-crond:
     name: send-appointment-reminder-crond
+    needs: appointment-frontend-cypress
     uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/pull-request-deploy.yaml
+++ b/.github/workflows/pull-request-deploy.yaml
@@ -61,11 +61,26 @@ jobs:
         echo REF:$REF
         echo "::set-output name=ref::$REF"
 
+  ##### TEST ###################################################################
+
+  appointment-frontend-cypress:
+    name: Appointment Frontend Cypress
+    uses: bcgov/queue-management/.github/workflows/reusable-appointment-frontend-cypress.yaml@master
+    secrets:
+      bceid-endpoint: ${{ secrets.CYPRESS_BCEID_ENDPOINT }}
+      bceid-password: ${{ secrets.CYPRESS_BCEID_PASSWORD }}
+      bceid-username: ${{ secrets.CYPRESS_BCEID_USERNAME }}
+      cypress-project-id: ${{ secrets.CYPRESS_PROJECT_ID }}
+      cypress-record-key: ${{ secrets.CYPRESS_RECORD_KEY }}
+      keycloak-auth-url: ${{ secrets.KEYCLOAK_AUTH_URL_DEV }}/auth/
+      keycloak-client: ${{ secrets.KEYCLOAK_APPOINTMENTS_FRONTEND_CLIENT }}
+      keycloak-realm: ${{ secrets.KEYCLOAK_REALM }}
+
   ##### BUILD ##################################################################
 
   appointment-frontend:
     name: appointment-frontend
-    needs: parse-inputs
+    needs: [parse-inputs, appointment-frontend-cypress]
     uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -88,7 +103,7 @@ jobs:
 
   feedback-api:
     name: feedback-api
-    needs: parse-inputs
+    needs: [parse-inputs, appointment-frontend-cypress]
     uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
@@ -108,7 +123,7 @@ jobs:
 
   notifications-api:
     name: notifications-api
-    needs: parse-inputs
+    needs: [parse-inputs, appointment-frontend-cypress]
     uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
@@ -128,7 +143,7 @@ jobs:
 
   queue-management-api:
     name: queue-management-api
-    needs: parse-inputs
+    needs: [parse-inputs, appointment-frontend-cypress]
     uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -151,7 +166,7 @@ jobs:
 
   queue-management-frontend:
     name: queue-management-frontend
-    needs: parse-inputs
+    needs: [parse-inputs, appointment-frontend-cypress]
     uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
@@ -174,7 +189,7 @@ jobs:
 
   send-appointment-reminder-crond:
     name: send-appointment-reminder-crond
-    needs: parse-inputs
+    needs: [parse-inputs, appointment-frontend-cypress]
     uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}

--- a/.github/workflows/reusable-appointment-frontend-cypress.yaml
+++ b/.github/workflows/reusable-appointment-frontend-cypress.yaml
@@ -1,0 +1,86 @@
+name: Appointment Frontend Cypress
+on:
+  workflow_call:
+    secrets:
+      bceid-endpoint:
+        required: true
+      bceid-password:
+        required: true
+      bceid-username:
+        required: true
+      cypress-project-id:
+        required: true
+      cypress-record-key:
+        required: true
+      keycloak-auth-url:
+        required: true
+      keycloak-client:
+        required: true
+      keycloak-realm:
+        required: true
+
+jobs:
+  cypress:
+    name: Cypress
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Configuration Files
+        run: |
+          mkdir -p appointment-frontend/public/config/kc
+
+          cat << EOF > appointment-frontend/public/config/configuration.json
+          {
+            "FEEDBACK_ENABLED": true,
+            "KEYCLOAK_CONFIG_URL": "./public/config/kc/keycloak-public.json",
+            "VUE_APP_FOOTER_LINKS": "https://www.icbc.com/locators",
+            "VUE_APP_FOOTER_MSG": "Looking for ICBC Services? Ensure you are at the right place by visiting {link} icbc.com/locators",
+            "VUE_APP_HEADER_LINKS": "https://www.gov.bc.ca/bcservicescardapp{link}https://www.bceid.ca",
+            "VUE_APP_HEADER_MSG": "Before you start – do you have the {link}BC Services Card app{link} or {link}Basic BCeID{link}? Login needed to confirm appointment.",
+            "VUE_APP_ROOT_API": "http://localhost:5000/api/v1"
+          }
+          EOF
+
+          cat << EOF > appointment-frontend/public/config/kc/keycloak-public.json
+          {
+            "auth-server-url": "${{ secrets.keycloak-auth-url }}",
+            "confidential-port": 0,
+            "public-client": true,
+            "realm": "${{ secrets.keycloak-realm }}",
+            "resource": "${{ secrets.keycloak-client }}",
+            "ssl-required": "external"
+          }
+          EOF
+
+          cat << EOF > appointment-frontend/cypress.env.json
+          {
+            "BCEID_ENDPOINT": "${{ secrets.bceid-endpoint }}",
+            "BCEID_PASSWORD": "${{ secrets.bceid-password }}",
+            "BCEID_USERNAME": "${{ secrets.bceid-username }}"
+          }
+          EOF
+
+      - name: Cypress Run
+        uses: cypress-io/github-action@v2
+        env:
+          CYPRESS_PROJECT_ID: ${{ secrets.cypress-project-id }}
+          CYPRESS_RECORD_KEY: ${{ secrets.cypress-record-key }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VUE_APP_PATH: /
+        with:
+          record: true
+          start: npm run serve -- --port 8081
+          wait-on: http://localhost:8081
+          working-directory: appointment-frontend
+
+      - name: On Failure Upload Screenshot Artifacts
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: appointment-frontend-cypress
+          path: |
+            appointment-frontend/cypress/screenshots
+            appointment-frontend/cypress/snapshots/image_snapshot/*/__diff_output__


### PR DESCRIPTION
Added the Cypress tests against the Appointment frontend as a first step before doing any builds.

- Updated documentation with new functionality
- Cypress test results will be uploaded to the [Cypress Dashboard](https://dashboard.cypress.io/projects/irceax/runs). If we don't find that the Dashboard offers any value, it can be removed
- If the Cypress tests fail, the results will be uploaded as an Artifact in GitHub Actions

There isn't really any way to test these changes, other than to merge the PR and then run the GitHub Actions for PR and master builds.

_(Note that you three are automatically requested as reviewers because I am touching sensitive files under the /.github directory)_