### PR TITLE
New vscode task to run alembic upgrade when API starts

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,6 +23,7 @@
   "extensions": [
     "bierner.markdown-preview-github-styles",
     "dbaeumer.vscode-eslint",
+    "github.vscode-pull-request-github",
     "ms-python.python",
     "ms-python.vscode-pylance",
     "mtxr.sqltools",

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ queue-env/
 # Visual Studio -- generally ignore, but allow shared configuration
 .vscode/*
 !.vscode/launch.json
+!.vscode/tasks.json
 
 # Project specific include/excludes
 api/postman/package-lock.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -64,6 +64,7 @@
       "cwd": "${workspaceFolder}/api",
       "gevent": true,
       "name": "queue_management_api",
+      "preLaunchTask": "alembic: upgrade - api",
       "program": "env/bin/gunicorn",
       "python": "${workspaceFolder}/api/env/bin/python",
       "request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+  "tasks": [
+    {
+      "args": [
+        "-c",
+        "cd ${workspaceFolder}/api; source env/bin/activate; python manage.py db upgrade"
+      ],
+      "command": "bash",
+      "detail": "python manage.py db upgrade",
+      "label": "alembic: upgrade - api",
+      "group": "build",
+      "presentation": {
+        "close": true,
+        "panel": "new",
+        "reveal": "always",
+      },
+      "type": "shell"
+    }
+  ],
+  "version": "2.0.0"
+}


### PR DESCRIPTION
Created a VSCode "Task" that does the Alembic upgrade in /api. Updated the launcher for /api to run the task before starting the API. This means that developers will automatically get Alembic changes applied when they update their repo and start the API.

Also added the VSCode extension for GitHub Pull Requests.

Testing: Tricky, and a fairly safe PR since it does not affect the actual application code. One way to test would be to pull the PR down and try it locally. 
 
Deploy: Not required.