### PR TITLE
Clean up stale imagestream tags in OpenShift

### DIFF
--- a/.github/workflows/cron-tag-cleanup.yaml
+++ b/.github/workflows/cron-tag-cleanup.yaml
@@ -1,0 +1,46 @@
+name: Cron Image Stream Tag Cleanup
+on:
+  schedule:
+    - cron: '30 20 * * 3'
+  workflow_dispatch:
+
+jobs:
+  qms-commits:
+    name: QMS Commits
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-commit.yaml@master
+    secrets:
+      namespace: ${{ secrets.LICENCE_PLATE_QMS }}-tools
+      openshift-api: ${{ secrets.OPENSHIFT_API }}
+      openshift-token: ${{ secrets.SA_PASSWORD_QMS_TOOLS }}
+    with:
+      number-to-keep: 3
+
+  theq-commits:
+    name: The Q Commits
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-commit.yaml@master
+    secrets:
+      namespace: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
+      openshift-api: ${{ secrets.OPENSHIFT_API }}
+      openshift-token: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
+    with:
+      number-to-keep: 3
+
+  qms-pull-requests:
+    name: QMS Pull Requests
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-pr.yaml@master
+    secrets:
+      namespace: ${{ secrets.LICENCE_PLATE_QMS }}-tools
+      openshift-api: ${{ secrets.OPENSHIFT_API }}
+      openshift-token: ${{ secrets.SA_PASSWORD_QMS_TOOLS }}
+    with:
+      days-to-keep: 7
+
+  theq-pull-requests:
+    name: The Q Pull Requests
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-pr.yaml@master
+    secrets:
+      namespace: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
+      openshift-api: ${{ secrets.OPENSHIFT_API }}
+      openshift-token: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
+    with:
+      days-to-keep: 7

--- a/.github/workflows/reusable-tag-cleanup-commit.yaml
+++ b/.github/workflows/reusable-tag-cleanup-commit.yaml
@@ -1,0 +1,99 @@
+name: Tag Cleanup for Commits
+on:
+  workflow_call:
+    inputs:
+      number-to-keep:
+        required: false
+        type: string
+        default: 3
+    secrets:
+      namespace:
+        required: true
+      openshift-api:
+        required: true
+      openshift-token:
+        required: true
+
+jobs:
+  image-stream-tag-cleanup:
+    name: Image Stream Tag Cleanup
+    runs-on: ubuntu-latest
+    steps:
+    - name: Log in to OpenShift
+      uses: redhat-actions/oc-login@v1
+      with:
+        namespace: ${{ secrets.namespace }}
+        openshift_server_url: ${{ secrets.openshift-api }}
+        openshift_token: ${{ secrets.openshift-token }}
+
+    - name: Image Stream Tag Cleanup
+      run: |
+        NAMESPACE=${{ secrets.namespace }}
+        NUMBER_TO_KEEP=${{ inputs.number-to-keep }}
+
+        IMAGE_STREAM_TAGS=$(oc -n $NAMESPACE get imagestreamtags -o json | jq -r \
+          '.items[] | "\(.image.metadata.name),\(.metadata.creationTimestamp),\(.metadata.name)"' | \
+          egrep ':commit-[0-9a-f]{7}$')
+
+        cleanup_imagestream () {
+          ITEMS=$*
+
+          if [ -z "$ITEMS" ]; then
+            return
+          fi
+
+          COUNT=$(echo $ITEMS | wc -w)
+          if [ $COUNT -le $NUMBER_TO_KEEP ]; then
+            for ITEM in $ITEMS; do
+              TAG=$(echo $ITEM | cut -d, -f2,3 | sed 's/,/:/')
+              echo Not deleting imagestreamtag $TAG because we keep the last \
+                $NUMBER_TO_KEEP in case we want to roll back.
+            done
+
+            return
+          fi
+
+          ITEMS=$(echo $ITEMS | sed 's/ /\n/g' | sort -n | \
+            head -n -$NUMBER_TO_KEEP)
+
+          for ITEM in $ITEMS; do
+            TAG=$(echo $ITEM | cut -d, -f2,3 | sed 's/,/:/')
+            COMMAND="oc -n $NAMESPACE delete imagestreamtag $TAG"
+            echo $COMMAND
+            # $COMMAND
+          done
+        }
+
+        DELETES=
+        CURRENT_IMAGE_STREAM=
+        for IMAGE_STREAM_TAG in $IMAGE_STREAM_TAGS; do
+          SHA=$(echo $IMAGE_STREAM_TAG | cut -d, -f1)
+          DATE=$(echo $IMAGE_STREAM_TAG | cut -d, -f2)
+          IMAGE_STREAM=$(echo $IMAGE_STREAM_TAG | cut -d, -f3 | cut -d: -f1)
+          TAG=$(echo $IMAGE_STREAM_TAG | cut -d, -f3 | cut -d: -f2)
+
+          if [ -z "$CURRENT_IMAGE_STREAM" ]; then
+            CURRENT_IMAGE_STREAM=$IMAGE_STREAM
+          elif [ $IMAGE_STREAM != $CURRENT_IMAGE_STREAM ]; then
+            cleanup_imagestream $DELETES
+            DELETES=
+
+            CURRENT_IMAGE_STREAM=$IMAGE_STREAM
+          fi
+
+          ENVS=$(oc -n $NAMESPACE get imagestreamtags -o json | jq -r \
+            '.items[] | "\(.metadata.name) \(.image.metadata.name)"' | \
+            egrep ^$IMAGE_STREAM: | grep -v $TAG | grep $SHA | \
+            cut -d' ' -f 1 | cut -d: -f2 | sort)
+
+          if [ -n "$ENVS" ]; then
+            echo Not deleting imagestreamtag $IMAGE_STREAM:$TAG because it is \
+              still tagged to: $ENVS
+
+            continue
+          fi
+
+          DELETES="$DELETES $DATE,$IMAGE_STREAM,$TAG"
+        done
+
+        cleanup_imagestream $DELETES

--- a/.github/workflows/reusable-tag-cleanup-pr.yaml
+++ b/.github/workflows/reusable-tag-cleanup-pr.yaml
@@ -1,0 +1,80 @@
+name: Tag Cleanup for PRs
+on:
+  workflow_call:
+    inputs:
+      days-to-keep:
+        required: false
+        type: string
+        default: 7
+    secrets:
+      namespace:
+        required: true
+      openshift-api:
+        required: true
+      openshift-token:
+        required: true
+
+jobs:
+  image-stream-tag-cleanup:
+    name: Image Stream Tag Cleanup
+    runs-on: ubuntu-latest
+    steps:
+    - name: Log in to OpenShift
+      uses: redhat-actions/oc-login@v1
+      with:
+        namespace: ${{ secrets.namespace }}
+        openshift_server_url: ${{ secrets.openshift-api }}
+        openshift_token: ${{ secrets.openshift-token }}
+
+    - name: Image Stream Tag Cleanup
+      run: |
+        NAMESPACE=${{ secrets.namespace }}
+
+        PR_NUMS=$(oc -n $NAMESPACE get imagestreamtags | awk '{ print $1 }' | \
+          egrep ':pr[0-9]+$' | cut -d: -f2 | sort -u | sed 's/^pr//')
+
+        if [ -z "$PR_NUMS" ]; then
+          echo No imagestreamtags for Pull Requests, nothing to do.
+
+          exit 0
+        fi
+
+        CUTOFF_DATE=$(date -I -d "${{ inputs.days-to-keep }} days ago")
+        echo Will delete all imagestreamtags for Pull Requests closed on or \
+          before $CUTOFF_DATE.
+
+        for PR_NUM in $PR_NUMS; do
+          echo
+          PULL_REQUEST=$(curl --no-progress-meter \
+            https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUM)
+
+          STATE=$(echo $PULL_REQUEST | jq -r '.state')
+          if [ $STATE != closed ]; then
+            echo Pull Request $PR_NUM has the state \"$STATE\" - ignoring \
+              until \"closed\".
+
+            continue
+          fi
+
+          CLOSE_DATE=$(echo $PULL_REQUEST | jq -r '.closed_at')
+          CLOSE_DATE=${CLOSE_DATE::10}
+          if [[ $CLOSE_DATE > $CUTOFF_DATE ]]; then
+            echo Pull Request $PR_NUM was closed $CLOSE_DATE, which is after \
+              the cutoff date $CUTOFF_DATE - will delete later.
+
+              continue
+          fi
+
+          echo Pull Request $PR_NUM was closed $CLOSE_DATE and can be deleted.
+          echo "::group::PR$PR_NUM"
+
+          DELETE_TAGS=$(oc -n $NAMESPACE get imagestreamtags | \
+            awk '{ print $1 }' | egrep ":pr$PR_NUM")
+          for DELETE_TAG in $DELETE_TAGS; do
+            COMMAND="oc -n $NAMESPACE delete imagestreamtag $DELETE_TAG"
+            echo $COMMAND
+            # $COMMAND
+          done
+
+          echo "::endgroup::"
+        done


### PR DESCRIPTION
The GitHub actions produce unique imagestream tags in the tools namespaces for each pending PR ("prXXX") and for each merged PR ("commit-XXXXXXX") that goes to production. Over time these tags accumulate and need to be deleted. This cron job in GitHub Actions will run weekly and delete closed "pr-XXX" tags over a week old, and all "commit-XXXXXXX" tags other than the most recent three (unless they are still tagged to dev/test/prod somewhere - then they're kept).