### PR TITLE
Actions fixes for duplicate variable name and restricting cron job

### DIFF
--- a/.github/workflows/cron-tag-cleanup.yaml
+++ b/.github/workflows/cron-tag-cleanup.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   qms-commits:
+    if: github.repository_owner == 'bcgov'
     name: QMS Commits
     uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-commit.yaml@master
     secrets:
@@ -16,6 +17,7 @@ jobs:
       number-to-keep: 3
 
   theq-commits:
+    if: github.repository_owner == 'bcgov'
     name: The Q Commits
     uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-commit.yaml@master
     secrets:
@@ -26,6 +28,7 @@ jobs:
       number-to-keep: 3
 
   qms-pull-requests:
+    if: github.repository_owner == 'bcgov'
     name: QMS Pull Requests
     uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-pr.yaml@master
     secrets:
@@ -36,6 +39,7 @@ jobs:
       days-to-keep: 7
 
   theq-pull-requests:
+    if: github.repository_owner == 'bcgov'
     name: The Q Pull Requests
     uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-pr.yaml@master
     secrets:

--- a/.github/workflows/reusable-tag-cleanup-commit.yaml
+++ b/.github/workflows/reusable-tag-cleanup-commit.yaml
@@ -57,8 +57,8 @@ jobs:
             head -n -$NUMBER_TO_KEEP)
 
           for ITEM in $ITEMS; do
-            TAG=$(echo $ITEM | cut -d, -f2,3 | sed 's/,/:/')
-            COMMAND="oc -n $NAMESPACE delete imagestreamtag $TAG"
+            ITEM_TAG=$(echo $ITEM | cut -d, -f2,3 | sed 's/,/:/')
+            COMMAND="oc -n $NAMESPACE delete imagestreamtag $ITEM_TAG"
             echo $COMMAND
             # $COMMAND
           done


### PR DESCRIPTION
Two problems were noted in the cron job that runs to clean up imagestreamtags in GitHub Actions:

1. The same variable name was used in two places in the script for the "commit" cleanup, and it was causing incorrect behaviour.
2. GitHub Actions were running the cron cleanup job in forks of the repository, and these forks were failing because the GitHub Secrets do not exist for the user - note also that we do not want this Action to run for all users.