### PR TITLE
GitHub Actions - Change default branch name to "main"

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,7 +11,7 @@ The GitHub Action `pull-request-deploy.yaml` is only run manually. It will:
 - Run OWASP ZAP tests
 - Run Newman tests if the deployment environment is The Q dev
 
-The GitHub Action `master-deploy.yaml` is only run manually. It will:
+The GitHub Action `main-deploy.yaml` is only run manually. It will:
 
 - Run Cypress tests against the Appointment Frontend
 - Build images using Dockerfile and Source to Image (S2I) builds

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,15 +1,9 @@
 # GitHub Actions CI/CD Pipelines
 
-The GitHub Action `pull-request-deploy.yaml` is only run manually. It will:
+The GitHub Action `cron-tag-cleanup.yaml` is run as a weekly cron job, but it can also be run on demand. It will:
 
-- Take a pull request number and environment as input parameters
-- Run Cypress tests against the Appointment Frontend
-- Build images using Dockerfile and Source to Image (S2I) builds
-- Push the built images to the required `-tools` namespace
-- Run `oc tag` to tag the images in the `-tools` namespace to `dev` (The Q or QMS) or `test` (The Q)
-- Wait for rollout of the new images in the deployment environment
-- Run OWASP ZAP tests
-- Run Newman tests if the deployment environment is The Q dev
+- Remove any OpenShift `imagestreamtag` created by the `pull-request-deploy.yaml` Action where the Pull Request was closed more than seven days ago
+- Remove any OpenShift `imagestreamtag` created by the `main-deploy.yaml` Action where the imagestreamtag is not tagged to any environment (`dev`, `test`, `prod`) and the `imagestreamtag` is not among the most recent three builds
 
 The GitHub Action `main-deploy.yaml` is only run manually. It will:
 
@@ -20,6 +14,17 @@ The GitHub Action `main-deploy.yaml` is only run manually. It will:
 - Run `oc tag` to tag the images in the two `-tools` namespaces for `dev`, then `test`, and then `prod` tags
 - After deployment to The Q dev, wait for rollout of the new images
 - After deployment to The Q dev, run Newman and OWASP ZAP tests
+
+The GitHub Action `pull-request-deploy.yaml` is only run manually. It will:
+
+- Take a pull request number and environment as input parameters
+- Run Cypress tests against the Appointment Frontend
+- Build images using Dockerfile and Source to Image (S2I) builds
+- Push the built images to the required `-tools` namespace
+- Run `oc tag` to tag the images in the `-tools` namespace to `dev` (The Q or QMS) or `test` (The Q)
+- Wait for rollout of the new images in the deployment environment
+- Run OWASP ZAP tests
+- Run Newman tests if the deployment environment is The Q dev
 
 ## Setup
 

--- a/.github/workflows/cron-tag-cleanup.yaml
+++ b/.github/workflows/cron-tag-cleanup.yaml
@@ -8,7 +8,7 @@ jobs:
   qms-commits:
     if: github.repository_owner == 'bcgov'
     name: QMS Commits
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-commit.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-commit.yaml@main
     secrets:
       namespace: ${{ secrets.LICENCE_PLATE_QMS }}-tools
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -19,7 +19,7 @@ jobs:
   theq-commits:
     if: github.repository_owner == 'bcgov'
     name: The Q Commits
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-commit.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-commit.yaml@main
     secrets:
       namespace: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -30,7 +30,7 @@ jobs:
   qms-pull-requests:
     if: github.repository_owner == 'bcgov'
     name: QMS Pull Requests
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-pr.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-pr.yaml@main
     secrets:
       namespace: ${{ secrets.LICENCE_PLATE_QMS }}-tools
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -41,7 +41,7 @@ jobs:
   theq-pull-requests:
     if: github.repository_owner == 'bcgov'
     name: The Q Pull Requests
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-pr.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-pr.yaml@main
     secrets:
       namespace: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       openshift-api: ${{ secrets.OPENSHIFT_API }}

--- a/.github/workflows/main-deploy.yaml
+++ b/.github/workflows/main-deploy.yaml
@@ -1,4 +1,4 @@
-name: Master Deploy
+name: Main Deploy
 concurrency: 
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -11,7 +11,7 @@ jobs:
 
   appointment-frontend-cypress:
     name: Appointment Frontend Cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-appointment-frontend-cypress.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-appointment-frontend-cypress.yaml@main
     secrets:
       bceid-endpoint: ${{ secrets.CYPRESS_BCEID_ENDPOINT }}
       bceid-password: ${{ secrets.CYPRESS_BCEID_PASSWORD }}
@@ -27,7 +27,7 @@ jobs:
   appointment-frontend:
     name: appointment-frontend
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@main
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -47,7 +47,7 @@ jobs:
   feedback-api:
     name: feedback-api
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@main
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       namespace-theq-password: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
@@ -64,7 +64,7 @@ jobs:
   notifications-api:
     name: notifications-api
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@main
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       namespace-theq-password: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
@@ -81,7 +81,7 @@ jobs:
   queue-management-api:
     name: queue-management-api
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@main
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -101,7 +101,7 @@ jobs:
   queue-management-frontend:
     name: queue-management-frontend
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@main
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -121,7 +121,7 @@ jobs:
   send-appointment-reminder-crond:
     name: send-appointment-reminder-crond
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@main
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -153,7 +153,7 @@ jobs:
   tag-theq-dev:
     name: Tag The Q Dev
     needs: approve-theq-dev
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@main
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -166,7 +166,7 @@ jobs:
   wait-for-rollouts:
     name: Wait for Rollouts
     needs: tag-theq-dev
-    uses: bcgov/queue-management/.github/workflows/reusable-wait-for-rollouts.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-wait-for-rollouts.yaml@main
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -259,7 +259,7 @@ jobs:
   tag-theq-test:
     name: Tag The Q Test
     needs: approve-theq-test
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@main
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -282,7 +282,7 @@ jobs:
   tag-theq-stable:
     name: Tag The Q Stable
     needs: approve-theq-prod
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@main
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -295,7 +295,7 @@ jobs:
   tag-theq-prod:
     name: Tag The Q Prod
     needs: tag-theq-stable
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@main
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -320,7 +320,7 @@ jobs:
   tag-qms-dev:
     name: Tag QMS Dev
     needs: approve-qms-dev
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@main
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -343,7 +343,7 @@ jobs:
   tag-qms-test:
     name: Tag QMS Test
     needs: approve-qms-test
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@main
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -366,7 +366,7 @@ jobs:
   tag-qms-stable:
     name: Tag QMS Stable
     needs: approve-qms-prod
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@main
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -379,7 +379,7 @@ jobs:
   tag-qms-prod:
     name: Tag QMS Prod
     needs: tag-qms-stable
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@main
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}

--- a/.github/workflows/pull-request-deploy.yaml
+++ b/.github/workflows/pull-request-deploy.yaml
@@ -65,7 +65,7 @@ jobs:
 
   appointment-frontend-cypress:
     name: Appointment Frontend Cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-appointment-frontend-cypress.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-appointment-frontend-cypress.yaml@main
     secrets:
       bceid-endpoint: ${{ secrets.CYPRESS_BCEID_ENDPOINT }}
       bceid-password: ${{ secrets.CYPRESS_BCEID_PASSWORD }}
@@ -81,7 +81,7 @@ jobs:
   appointment-frontend:
     name: appointment-frontend
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@main
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -104,7 +104,7 @@ jobs:
   feedback-api:
     name: feedback-api
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@main
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       namespace-theq-password: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
@@ -124,7 +124,7 @@ jobs:
   notifications-api:
     name: notifications-api
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@main
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       namespace-theq-password: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
@@ -144,7 +144,7 @@ jobs:
   queue-management-api:
     name: queue-management-api
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@main
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -167,7 +167,7 @@ jobs:
   queue-management-frontend:
     name: queue-management-frontend
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@main
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -190,7 +190,7 @@ jobs:
   send-appointment-reminder-crond:
     name: send-appointment-reminder-crond
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@main
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -215,7 +215,7 @@ jobs:
   tag:
     name: Tag
     needs: [parse-inputs, appointment-frontend, feedback-api, notifications-api, queue-management-api, queue-management-frontend, send-appointment-reminder-crond]
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@main
     secrets:
       licence-plate: ${{ needs.parse-inputs.outputs.push-qms == 'true' && secrets.LICENCE_PLATE_QMS || secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -228,7 +228,7 @@ jobs:
   wait-for-rollouts:
     name: Wait for Rollouts
     needs: [parse-inputs, tag]
-    uses: bcgov/queue-management/.github/workflows/reusable-wait-for-rollouts.yaml@master
+    uses: bcgov/queue-management/.github/workflows/reusable-wait-for-rollouts.yaml@main
     secrets:
       licence-plate: ${{ needs.parse-inputs.outputs.push-qms == 'true' && secrets.LICENCE_PLATE_QMS || secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}

--- a/.github/workflows/reusable-build-dockerfile.yaml
+++ b/.github/workflows/reusable-build-dockerfile.yaml
@@ -5,7 +5,7 @@ on:
       ref:
         required: false
         type: string
-        default: master
+        default: main
       directory:
         required: true
         type: string

--- a/.github/workflows/reusable-build-s2i.yaml
+++ b/.github/workflows/reusable-build-s2i.yaml
@@ -5,7 +5,7 @@ on:
       ref:
         required: false
         type: string
-        default: master
+        default: main
       directory:
         required: true
         type: string


### PR DESCRIPTION
*** DRAFT ***

Update the GitHub Actions to use "main" as the default branch name for the repository. This needs to be merged immediately after changing the default branch name of the repository.