### PR TITLE
Actions: Reworked variable duplication that caused problems

### DIFF
--- a/.github/workflows/reusable-tag-cleanup-commit.yaml
+++ b/.github/workflows/reusable-tag-cleanup-commit.yaml
@@ -45,9 +45,9 @@ jobs:
           COUNT=$(echo $ITEMS | wc -w)
           if [ $COUNT -le $NUMBER_TO_KEEP ]; then
             for ITEM in $ITEMS; do
-              TAG=$(echo $ITEM | cut -d, -f2,3 | sed 's/,/:/')
-              echo Not deleting imagestreamtag $TAG because we keep the last \
-                $NUMBER_TO_KEEP in case we want to roll back.
+              ITEM_TAG=$(echo $ITEM | cut -d, -f2,3 | sed 's/,/:/')
+              echo Not deleting imagestreamtag $ITEM_TAG because we keep the \
+                last $NUMBER_TO_KEEP in case we want to roll back.
             done
 
             return


### PR DESCRIPTION
I found another variable name duplication bug that can potentially cause problems in the imagestreamtag cleanup.