### PR TITLE
Actions - enable oc delete for imagestreamtag cleanup

### DIFF
--- a/.github/workflows/openshift/service_account.yaml
+++ b/.github/workflows/openshift/service_account.yaml
@@ -36,6 +36,13 @@ objects:
       - imagestreams
     verbs:
       - create
+  - apiGroups:
+      - image.openshift.io
+    resources:
+      - imagestreamtags
+    verbs:
+      - delete
+      - list
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: RoleBinding
   metadata:

--- a/.github/workflows/reusable-tag-cleanup-commit.yaml
+++ b/.github/workflows/reusable-tag-cleanup-commit.yaml
@@ -60,7 +60,7 @@ jobs:
             ITEM_TAG=$(echo $ITEM | cut -d, -f2,3 | sed 's/,/:/')
             COMMAND="oc -n $NAMESPACE delete imagestreamtag $ITEM_TAG"
             echo $COMMAND
-            # $COMMAND
+            $COMMAND
           done
         }
 

--- a/.github/workflows/reusable-tag-cleanup-pr.yaml
+++ b/.github/workflows/reusable-tag-cleanup-pr.yaml
@@ -73,7 +73,7 @@ jobs:
           for DELETE_TAG in $DELETE_TAGS; do
             COMMAND="oc -n $NAMESPACE delete imagestreamtag $DELETE_TAG"
             echo $COMMAND
-            # $COMMAND
+            $COMMAND
           done
 
           echo "::endgroup::"


### PR DESCRIPTION
The cron job for the `imagestreamtag` cleanup previously had the `oc delete imagestreamtag ...` command commented out until we were sure it was all working correctly. Now that the latest run has been successful, the `oc delete` commands can be enabled.

Also updated the documentation for permissions for the `github-actions` service account to allow listing and deleting `imagestreamtag` objects.