### PR TITLE
Simplifed "uses" for easier development

### DIFF
--- a/.github/workflows/cron-tag-cleanup.yaml
+++ b/.github/workflows/cron-tag-cleanup.yaml
@@ -8,7 +8,7 @@ jobs:
   qms-commits:
     if: github.repository_owner == 'bcgov'
     name: QMS Commits
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-commit.yaml@master
+    uses: ./.github/workflows/reusable-tag-cleanup-commit.yaml
     secrets:
       namespace: ${{ secrets.LICENCE_PLATE_QMS }}-tools
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -19,7 +19,7 @@ jobs:
   theq-commits:
     if: github.repository_owner == 'bcgov'
     name: The Q Commits
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-commit.yaml@master
+    uses: ./.github/workflows/reusable-tag-cleanup-commit.yaml
     secrets:
       namespace: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -30,7 +30,7 @@ jobs:
   qms-pull-requests:
     if: github.repository_owner == 'bcgov'
     name: QMS Pull Requests
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-pr.yaml@master
+    uses: ./.github/workflows/reusable-tag-cleanup-pr.yaml
     secrets:
       namespace: ${{ secrets.LICENCE_PLATE_QMS }}-tools
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -41,7 +41,7 @@ jobs:
   theq-pull-requests:
     if: github.repository_owner == 'bcgov'
     name: The Q Pull Requests
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-cleanup-pr.yaml@master
+    uses: ./.github/workflows/reusable-tag-cleanup-pr.yaml
     secrets:
       namespace: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       openshift-api: ${{ secrets.OPENSHIFT_API }}

--- a/.github/workflows/master-deploy.yaml
+++ b/.github/workflows/master-deploy.yaml
@@ -11,7 +11,7 @@ jobs:
 
   appointment-frontend-cypress:
     name: Appointment Frontend Cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-appointment-frontend-cypress.yaml@master
+    uses: ./.github/workflows/reusable-appointment-frontend-cypress.yaml
     secrets:
       bceid-endpoint: ${{ secrets.CYPRESS_BCEID_ENDPOINT }}
       bceid-password: ${{ secrets.CYPRESS_BCEID_PASSWORD }}
@@ -27,7 +27,7 @@ jobs:
   appointment-frontend:
     name: appointment-frontend
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: ./.github/workflows/reusable-build-dockerfile.yaml
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -47,7 +47,7 @@ jobs:
   feedback-api:
     name: feedback-api
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: ./.github/workflows/reusable-build-s2i.yaml
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       namespace-theq-password: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
@@ -64,7 +64,7 @@ jobs:
   notifications-api:
     name: notifications-api
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: ./.github/workflows/reusable-build-s2i.yaml
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       namespace-theq-password: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
@@ -81,7 +81,7 @@ jobs:
   queue-management-api:
     name: queue-management-api
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: ./.github/workflows/reusable-build-s2i.yaml
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -101,7 +101,7 @@ jobs:
   queue-management-frontend:
     name: queue-management-frontend
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: ./.github/workflows/reusable-build-dockerfile.yaml
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -121,7 +121,7 @@ jobs:
   send-appointment-reminder-crond:
     name: send-appointment-reminder-crond
     needs: appointment-frontend-cypress
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: ./.github/workflows/reusable-build-dockerfile.yaml
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -153,7 +153,7 @@ jobs:
   tag-theq-dev:
     name: Tag The Q Dev
     needs: approve-theq-dev
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -166,7 +166,7 @@ jobs:
   wait-for-rollouts:
     name: Wait for Rollouts
     needs: tag-theq-dev
-    uses: bcgov/queue-management/.github/workflows/reusable-wait-for-rollouts.yaml@master
+    uses: ./.github/workflows/reusable-wait-for-rollouts.yaml
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -259,7 +259,7 @@ jobs:
   tag-theq-test:
     name: Tag The Q Test
     needs: approve-theq-test
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -282,7 +282,7 @@ jobs:
   tag-theq-stable:
     name: Tag The Q Stable
     needs: approve-theq-prod
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -295,7 +295,7 @@ jobs:
   tag-theq-prod:
     name: Tag The Q Prod
     needs: tag-theq-stable
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -320,7 +320,7 @@ jobs:
   tag-qms-dev:
     name: Tag QMS Dev
     needs: approve-qms-dev
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -343,7 +343,7 @@ jobs:
   tag-qms-test:
     name: Tag QMS Test
     needs: approve-qms-test
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -366,7 +366,7 @@ jobs:
   tag-qms-stable:
     name: Tag QMS Stable
     needs: approve-qms-prod
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -379,7 +379,7 @@ jobs:
   tag-qms-prod:
     name: Tag QMS Prod
     needs: tag-qms-stable
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
       licence-plate: ${{ secrets.LICENCE_PLATE_QMS }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}

--- a/.github/workflows/pull-request-deploy.yaml
+++ b/.github/workflows/pull-request-deploy.yaml
@@ -66,7 +66,7 @@ jobs:
   appointment-frontend-cypress:
     name: Appointment Frontend Cypress
     needs: parse-inputs
-    uses: bcgov/queue-management/.github/workflows/reusable-appointment-frontend-cypress.yaml@master
+    uses: ./.github/workflows/reusable-appointment-frontend-cypress.yaml
     secrets:
       bceid-endpoint: ${{ secrets.CYPRESS_BCEID_ENDPOINT }}
       bceid-password: ${{ secrets.CYPRESS_BCEID_PASSWORD }}
@@ -84,7 +84,7 @@ jobs:
   appointment-frontend:
     name: appointment-frontend
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: ./.github/workflows/reusable-build-dockerfile.yaml
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -107,7 +107,7 @@ jobs:
   feedback-api:
     name: feedback-api
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: ./.github/workflows/reusable-build-s2i.yaml
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       namespace-theq-password: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
@@ -127,7 +127,7 @@ jobs:
   notifications-api:
     name: notifications-api
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: ./.github/workflows/reusable-build-s2i.yaml
     secrets:
       namespace-theq: ${{ secrets.LICENCE_PLATE_THEQ }}-tools
       namespace-theq-password: ${{ secrets.SA_PASSWORD_THEQ_TOOLS }}
@@ -147,7 +147,7 @@ jobs:
   queue-management-api:
     name: queue-management-api
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-s2i.yaml@master
+    uses: ./.github/workflows/reusable-build-s2i.yaml
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -170,7 +170,7 @@ jobs:
   queue-management-frontend:
     name: queue-management-frontend
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: ./.github/workflows/reusable-build-dockerfile.yaml
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -193,7 +193,7 @@ jobs:
   send-appointment-reminder-crond:
     name: send-appointment-reminder-crond
     needs: [parse-inputs, appointment-frontend-cypress]
-    uses: bcgov/queue-management/.github/workflows/reusable-build-dockerfile.yaml@master
+    uses: ./.github/workflows/reusable-build-dockerfile.yaml
     secrets:
       artifactory-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
       artifactory-registry: ${{ secrets.ARTIFACTORY_REGISTRY }}
@@ -218,7 +218,7 @@ jobs:
   tag:
     name: Tag
     needs: [parse-inputs, appointment-frontend, feedback-api, notifications-api, queue-management-api, queue-management-frontend, send-appointment-reminder-crond]
-    uses: bcgov/queue-management/.github/workflows/reusable-tag-image.yaml@master
+    uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
       licence-plate: ${{ needs.parse-inputs.outputs.push-qms == 'true' && secrets.LICENCE_PLATE_QMS || secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}
@@ -231,7 +231,7 @@ jobs:
   wait-for-rollouts:
     name: Wait for Rollouts
     needs: [parse-inputs, tag]
-    uses: bcgov/queue-management/.github/workflows/reusable-wait-for-rollouts.yaml@master
+    uses: ./.github/workflows/reusable-wait-for-rollouts.yaml
     secrets:
       licence-plate: ${{ needs.parse-inputs.outputs.push-qms == 'true' && secrets.LICENCE_PLATE_QMS || secrets.LICENCE_PLATE_THEQ }}
       openshift-api: ${{ secrets.OPENSHIFT_API }}


### PR DESCRIPTION
Changed the GitHub Actions "uses" clauses for reusable workflows so that it isn't tied to the organization (bcgov), repository (queue-management), and branch (master). This will make it much easier for developers to run the workflows in their own forks, for use in testing changes.

Side effect - this means the change to the Actions will be much smaller when the default repository branch is renamed from "master" to "main".

This change is limited to the GitHub actions, and changes cannot be confirmed until they are merged and the Actions are run. Does not require a deployment.