### PR TITLE
GitHub Actions: Switch the default repository branch name to "main"

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -11,7 +11,7 @@ The GitHub Action `pull-request-deploy.yaml` is only run manually. It will:
 - Run OWASP ZAP tests
 - Run Newman tests if the deployment environment is The Q dev
 
-The GitHub Action `master-deploy.yaml` is only run manually. It will:
+The GitHub Action `main-deploy.yaml` is only run manually. It will:
 
 - Run Cypress tests against the Appointment Frontend
 - Build images using Dockerfile and Source to Image (S2I) builds

--- a/.github/workflows/main-deploy.yaml
+++ b/.github/workflows/main-deploy.yaml
@@ -1,4 +1,4 @@
-name: Master Deploy
+name: Main Deploy
 concurrency: 
   group: ${{ github.workflow }}
   cancel-in-progress: true

--- a/.github/workflows/reusable-appointment-frontend-cypress.yaml
+++ b/.github/workflows/reusable-appointment-frontend-cypress.yaml
@@ -5,7 +5,7 @@ on:
       ref:
         required: false
         type: string
-        default: master
+        default: main
     secrets:
       bceid-endpoint:
         required: true

--- a/.github/workflows/reusable-build-dockerfile.yaml
+++ b/.github/workflows/reusable-build-dockerfile.yaml
@@ -5,7 +5,7 @@ on:
       ref:
         required: false
         type: string
-        default: master
+        default: main
       directory:
         required: true
         type: string

--- a/.github/workflows/reusable-build-s2i.yaml
+++ b/.github/workflows/reusable-build-s2i.yaml
@@ -5,7 +5,7 @@ on:
       ref:
         required: false
         type: string
-        default: master
+        default: main
       directory:
         required: true
         type: string


### PR DESCRIPTION
As part of switching the default repository branch name to "main", the Actions need to be updated to use the correct branch name.

No deployment is needed, all changes are within the GitHub Actions.