### PR TITLE
Appointment reminder: switch default branch to "main"

### DIFF
--- a/jobs/appointment_reminder/requirements.txt
+++ b/jobs/appointment_reminder/requirements.txt
@@ -7,4 +7,4 @@ pytz
 notifications-python-client
 
 # TODO: Can this be an env variable? Or can it be relative?
--e git+https://github.com/bcgov/queue-management.git@master#egg=queue_api&subdirectory=api
+-e git+https://github.com/bcgov/queue-management.git@main#egg=queue_api&subdirectory=api


### PR DESCRIPTION
One item was missed in the renaming of the default repo branch to "main": one of the requirements in the appointment reminder cron job.