### PR TITLE
Do full and clean dependency rebuild for devcontainers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,9 @@ queue-env/
 !.vscode/launch.json
 !.vscode/tasks.json
 
+# Visual Studio Code devcontainers -- ignore dependency installation logs.
+.devcontainer/logs
+
 # Project specific include/excludes
 api/postman/package-lock.json
 /frontend/public/static/keycloak/


### PR DESCRIPTION
Ran into a hard to track down problem because rebuilding the containers was not clearing out the `node_modules` directories. This meant that doing a rebuild to pick up dependency changes wasn't necessarily doing so. This will cause longer rebuild times, but a long and correct rebuild is better than a fast incorrect one.

While I was in the file:
- Converted old-style backtick \`foo\` subprocesses to the modern nestable \$(foo) format
- Logging the output of the install commands to .devcontainer/logs
- Moved database commands out of the dependency installation and into their own section

Oddity - uncommenting the feedback-api and notifications-api sections results in the pip installs failing with timeouts. Left them commented until there is time to figure that out.

**These changes do not require a deployment, as it is entirely for VSCode devcontainers.**