### PR TITLE
GitHub Actions: Remove use of deprecated set-output command

### DIFF
--- a/.github/workflows/main-deploy.yaml
+++ b/.github/workflows/main-deploy.yaml
@@ -43,6 +43,8 @@ jobs:
       directory: appointment-frontend
       image-name: appointment-nginx-frontend
       image-tags: commit-${GITHUB_SHA::7} latest
+      push-qms: ${{ github.repository_owner == 'bcgov' }}
+      push-theq: ${{ github.repository_owner == 'bcgov' }}
 
   feedback-api:
     name: feedback-api
@@ -60,6 +62,8 @@ jobs:
       directory: feedback-api
       image-name: feedback-api
       image-tags: commit-${GITHUB_SHA::7} latest
+      push-qms: ${{ github.repository_owner == 'bcgov' }}
+      push-theq: ${{ github.repository_owner == 'bcgov' }}
 
   notifications-api:
     name: notifications-api
@@ -77,6 +81,8 @@ jobs:
       directory: notifications-api
       image-name: notifications-api
       image-tags: commit-${GITHUB_SHA::7} latest
+      push-qms: ${{ github.repository_owner == 'bcgov' }}
+      push-theq: ${{ github.repository_owner == 'bcgov' }}
 
   queue-management-api:
     name: queue-management-api
@@ -97,6 +103,8 @@ jobs:
       directory: api
       image-name: queue-management-api
       image-tags: commit-${GITHUB_SHA::7} latest
+      push-qms: ${{ github.repository_owner == 'bcgov' }}
+      push-theq: ${{ github.repository_owner == 'bcgov' }}
 
   queue-management-frontend:
     name: queue-management-frontend
@@ -117,6 +125,8 @@ jobs:
       directory: frontend
       image-name: queue-management-nginx-frontend
       image-tags: commit-${GITHUB_SHA::7} latest
+      push-qms: ${{ github.repository_owner == 'bcgov' }}
+      push-theq: ${{ github.repository_owner == 'bcgov' }}
 
   send-appointment-reminder-crond:
     name: send-appointment-reminder-crond
@@ -137,11 +147,14 @@ jobs:
       directory: jobs/appointment_reminder
       image-name: send-appointment-reminder-crond
       image-tags: commit-${GITHUB_SHA::7} latest
+      push-qms: ${{ github.repository_owner == 'bcgov' }}
+      push-theq: ${{ github.repository_owner == 'bcgov' }}
 
   ##### DEPLOY THE Q ###########################################################
 
   approve-theq-dev:
     name: Approve Deploy to The Q Dev
+    if: github.repository_owner == 'bcgov'
     needs: [appointment-frontend, feedback-api, notifications-api, queue-management-api, queue-management-frontend, send-appointment-reminder-crond]
     environment: The Q Dev
     runs-on: ubuntu-latest
@@ -152,6 +165,7 @@ jobs:
 
   tag-theq-dev:
     name: Tag The Q Dev
+    if: github.repository_owner == 'bcgov'
     needs: approve-theq-dev
     uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
@@ -165,6 +179,7 @@ jobs:
 
   wait-for-rollouts:
     name: Wait for Rollouts
+    if: github.repository_owner == 'bcgov'
     needs: tag-theq-dev
     uses: ./.github/workflows/reusable-wait-for-rollouts.yaml
     secrets:
@@ -248,6 +263,7 @@ jobs:
 
   approve-theq-test:
     name: Approve Deploy to The Q Test
+    if: github.repository_owner == 'bcgov'
     needs: [newman-theq, owasp-staff, owasp-appointment]
     environment: The Q Test
     runs-on: ubuntu-latest
@@ -258,6 +274,7 @@ jobs:
 
   tag-theq-test:
     name: Tag The Q Test
+    if: github.repository_owner == 'bcgov'
     needs: approve-theq-test
     uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
@@ -271,6 +288,7 @@ jobs:
 
   approve-theq-prod:
     name: Approve Deploy to The Q Prod
+    if: github.repository_owner == 'bcgov'
     needs: tag-theq-test
     environment: The Q Prod
     runs-on: ubuntu-latest
@@ -281,6 +299,7 @@ jobs:
 
   tag-theq-stable:
     name: Tag The Q Stable
+    if: github.repository_owner == 'bcgov'
     needs: approve-theq-prod
     uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
@@ -294,6 +313,7 @@ jobs:
 
   tag-theq-prod:
     name: Tag The Q Prod
+    if: github.repository_owner == 'bcgov'
     needs: tag-theq-stable
     uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
@@ -309,6 +329,7 @@ jobs:
 
   approve-qms-dev:
     name: Approve Deploy to QMS Dev
+    if: github.repository_owner == 'bcgov'
     needs: [appointment-frontend, feedback-api, notifications-api, queue-management-api, queue-management-frontend, send-appointment-reminder-crond]
     environment: QMS Dev
     runs-on: ubuntu-latest
@@ -319,6 +340,7 @@ jobs:
 
   tag-qms-dev:
     name: Tag QMS Dev
+    if: github.repository_owner == 'bcgov'
     needs: approve-qms-dev
     uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
@@ -332,6 +354,7 @@ jobs:
 
   approve-qms-test:
     name: Approve Deploy to QMS Test
+    if: github.repository_owner == 'bcgov'
     needs: tag-qms-dev
     environment: QMS Test
     runs-on: ubuntu-latest
@@ -342,6 +365,7 @@ jobs:
 
   tag-qms-test:
     name: Tag QMS Test
+    if: github.repository_owner == 'bcgov'
     needs: approve-qms-test
     uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
@@ -355,6 +379,7 @@ jobs:
 
   approve-qms-prod:
     name: Approve Deploy to QMS Prod
+    if: github.repository_owner == 'bcgov'
     needs: tag-qms-test
     environment: QMS Prod
     runs-on: ubuntu-latest
@@ -365,6 +390,7 @@ jobs:
 
   tag-qms-stable:
     name: Tag QMS Stable
+    if: github.repository_owner == 'bcgov'
     needs: approve-qms-prod
     uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
@@ -378,6 +404,7 @@ jobs:
 
   tag-qms-prod:
     name: Tag QMS Prod
+    if: github.repository_owner == 'bcgov'
     needs: tag-qms-stable
     uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:

--- a/.github/workflows/pull-request-deploy.yaml
+++ b/.github/workflows/pull-request-deploy.yaml
@@ -35,7 +35,8 @@ jobs:
       id: parse
       run: |
         # Gets "dev" or "test".
-        ENVIRONMENT=$(echo ${{ github.event.inputs.namespace }} | awk -F' ' '{print $NF}' | tr '[:upper:]' '[:lower:]')
+        ENVIRONMENT=$(echo ${{ github.event.inputs.namespace }} | \
+            awk -F' ' '{print $NF}' | tr '[:upper:]' '[:lower:]')
         echo ENVIRONMENT:$ENVIRONMENT
         echo "::set-output name=environment::$ENVIRONMENT"
 
@@ -43,7 +44,11 @@ jobs:
         echo IMAGE_TAG:$IMAGE_TAG
         echo "::set-output name=image-tag::$IMAGE_TAG"
 
-        if [[ "${{ github.event.inputs.namespace }}" == QMS* ]]; then
+        if [ $GITHUB_REPOSITORY_OWNER != "bcgov" ]; then
+          # Never push in forks - useful and safer for development.
+          PUSH_QMS=false
+          PUSH_THEQ=false
+        elif [[ "${{ github.event.inputs.namespace }}" == QMS* ]]; then
           PUSH_QMS=true
           PUSH_THEQ=false
         else
@@ -217,6 +222,7 @@ jobs:
 
   tag:
     name: Tag
+    if: github.repository_owner == 'bcgov'
     needs: [parse-inputs, appointment-frontend, feedback-api, notifications-api, queue-management-api, queue-management-frontend, send-appointment-reminder-crond]
     uses: ./.github/workflows/reusable-tag-image.yaml
     secrets:
@@ -230,6 +236,7 @@ jobs:
 
   wait-for-rollouts:
     name: Wait for Rollouts
+    if: github.repository_owner == 'bcgov'
     needs: [parse-inputs, tag]
     uses: ./.github/workflows/reusable-wait-for-rollouts.yaml
     secrets:

--- a/.github/workflows/pull-request-deploy.yaml
+++ b/.github/workflows/pull-request-deploy.yaml
@@ -38,11 +38,11 @@ jobs:
         ENVIRONMENT=$(echo ${{ github.event.inputs.namespace }} | \
             awk -F' ' '{print $NF}' | tr '[:upper:]' '[:lower:]')
         echo ENVIRONMENT:$ENVIRONMENT
-        echo "::set-output name=environment::$ENVIRONMENT"
+        echo "environment=$ENVIRONMENT" >> $GITHUB_OUTPUT
 
         IMAGE_TAG=pr${{ github.event.inputs.pr-number }}
         echo IMAGE_TAG:$IMAGE_TAG
-        echo "::set-output name=image-tag::$IMAGE_TAG"
+        echo "image-tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
 
         if [ $GITHUB_REPOSITORY_OWNER != "bcgov" ]; then
           # Never push in forks - useful and safer for development.
@@ -57,14 +57,14 @@ jobs:
         fi
 
         echo PUSH_QMS:$PUSH_QMS
-        echo "::set-output name=push-qms::$PUSH_QMS"
+        echo "push-qms=$PUSH_QMS" >> $GITHUB_OUTPUT
 
         echo PUSH_THEQ:$PUSH_THEQ
-        echo "::set-output name=push-theq::$PUSH_THEQ"
+        echo "push-theq=$PUSH_THEQ" >> $GITHUB_OUTPUT
 
         REF=refs/pull/${{ github.event.inputs.pr-number }}/head
         echo REF:$REF
-        echo "::set-output name=ref::$REF"
+        echo "ref=$REF" >> $GITHUB_OUTPUT
 
   ##### TEST ###################################################################
 


### PR DESCRIPTION
GitHub Actions has recently deprecated the `set-output` command. This PR contains the following:

1. Add if clauses to the workflow jobs so that some jobs will only run in the bcgov repo (that is, not in forks). This means that developers can run the flows in their forks to test code changes, and it lessens the likelihood of accidentally changing OpenShift when doing so
1. Update the PR action to use environment files instead of the deprecated `set-output` command
1. Update the documentation to describe the cron workflow for removing image stream tags - this was omitted in previous work
1. Update the documentation to include version numbers of external workflows. This makes it easy to occasionally run through the list and look for updates.

Test strategy - carefully review code, merge, and watch the main and pr builds carefully the next time they are run.

**This PR only contains changes to GitHub Actions and does not require a deployment**