### PR TITLE
URL changed from dev.oidc.gov.bc.ca to dev.loginproxy.gov.bc.ca

### DIFF
--- a/tests/loadtesting/functions.js
+++ b/tests/loadtesting/functions.js
@@ -1,7 +1,8 @@
 
 const fetch = require('node-fetch');
 
-KEYCLOAK_URI = 'https://dev.oidc.gov.bc.ca/auth'
+//KEYCLOAK_URI = 'https://dev.oidc.gov.bc.ca/auth'
+KEYCLOAK_URI = 'https://dev.loginproxy.gov.bc.ca/auth'
 KEYCLOAK_CLIENT = 'cfms-dev-staff'
 
 // This implementation assumes it never has to refresh a token and they never expire


### PR DESCRIPTION
As discussed with Linh. changing URL from dev.oidc.gov.bc.ca to dev.loginproxy.gov.bc.ca in /workspace/tests/loadtesting/functions.js