### PR TITLE
updated required expiration days

### DIFF
--- a/frontend/src/components/exams/add-exam-modal.vue
+++ b/frontend/src/components/exams/add-exam-modal.vue
@@ -342,7 +342,7 @@ export default class AddExamModal extends Vue {
       return
     case 'pesticide':
       this.resetModal()
-      const expiry = moment().add(60, 'd')
+      const expiry = moment().add(90, 'd')
       this.captureExamDetail({ key: 'expiry_date', value: expiry })
       return
     default:


### PR DESCRIPTION
User story

As an exam manager
I want pesticide exams to have a 90 day expiry date by default
So that I don’t need to manually change each one

Description

Ministry of Environment has approved SBC’s request to extend the expiry date for Pesticide & Transportation of Hazardous Waste (THW) Exams from 60 days to 90 days.

The Q will require adjusting to move the expiry date to reflect this. The default expiry date for a pesticide exam is set as the expiry constant in the front-end [queue-management/frontend/src/components/exams/add-exam-modal.vue at 49b7a288fb27be1f99e7479aac8c07871ae91002 · bcgov/queue-management](https://github.com/bcgov/queue-management/blob/49b7a288fb27be1f99e7479aac8c07871ae91002/frontend/src/components/exams/add-exam-modal.vue#L343C5-L347C13). This value needs to be updated.

Acceptance criteria

New Pesticide & THW exams are created with a 90 day expiry