### PR TITLE
Add api client for services

### DIFF
--- a/appointment-booking/app/api/services.ts
+++ b/appointment-booking/app/api/services.ts
@@ -1,0 +1,113 @@
+// Service type used by the frontend after mapping from the API.
+export type OnlineAvailability = 'SHOW' | 'DISABLE'
+
+export type Service = {
+  id: number
+  name: string
+  onlineAvailability: OnlineAvailability
+  isOnlineBookable: boolean
+}
+
+// API response row from GET /api/v1/services/.
+type ApiService = {
+  service_id: number
+  service_name: string
+  external_service_name: string | null
+  actual_service_ind: number
+  display_dashboard_ind: number
+  online_availability: string | null
+  deleted: string | null
+}
+
+type ApiServicesResponse = {
+  services: ApiService[]
+  errors: Record<string, unknown>
+}
+
+function apiBaseUrl() {
+  // VITE_Q_API_URL should include /api/v1, e.g. http://localhost:5000/api/v1
+  const fromEnv = import.meta.env.VITE_Q_API_URL
+  if (fromEnv) {
+    return fromEnv.replace(/\/$/, '')
+  }
+  return '/api/v1'
+}
+
+// API sends values like "Availability.SHOW" or sometimes just "SHOW".
+function readAvailability(value: string | null): OnlineAvailability | null {
+  if (!value) {
+    return null
+  }
+
+  if (value === 'HIDE' || value.endsWith('.HIDE')) {
+    return null
+  }
+
+  if (value === 'SHOW' || value.endsWith('.SHOW')) {
+    return 'SHOW'
+  }
+
+  if (value === 'DISABLE' || value.endsWith('.DISABLE')) {
+    return 'DISABLE'
+  }
+
+  return null
+}
+
+function keepForPublicList(row: ApiService): OnlineAvailability | null {
+  // Public service filter rules.
+  if (row.actual_service_ind !== 1) {
+    return null
+  }
+
+  if (row.display_dashboard_ind !== 1) {
+    return null
+  }
+
+  if (row.deleted) {
+    return null // skip deleted services; global /services/ still returns them
+  }
+
+  const availability = readAvailability(row.online_availability)
+  if (availability === 'SHOW' || availability === 'DISABLE') {
+    return availability
+  }
+
+  return null
+}
+
+function mapRow(row: ApiService, availability: OnlineAvailability): Service {
+  // Frontend label: external_service_name, or service_name as fallback.
+  const name = row.external_service_name?.trim() || row.service_name
+
+  return {
+    id: row.service_id,
+    name,
+    onlineAvailability: availability,
+    isOnlineBookable: availability === 'SHOW',
+  }
+}
+
+// Fetch from the API and filter here, not in the UI.
+export async function getPublicServices(): Promise<Service[]> {
+  const url = `${apiBaseUrl()}/services/`
+  const response = await fetch(url)
+
+  if (!response.ok) {
+    throw new Error(`Could not load services (${response.status})`)
+  }
+
+  const body = (await response.json()) as ApiServicesResponse
+  const rows = body.services ?? []
+  const services: Service[] = []
+
+  for (const row of rows) {
+    const availability = keepForPublicList(row)
+    if (!availability) {
+      continue
+    }
+    services.push(mapRow(row, availability))
+  }
+
+  return services
+}

--- a/appointment-booking/app/api/services.ts
+++ b/appointment-booking/app/api/services.ts
@@ -73,7 +73,7 @@ function keepForPublicList(row: ApiService): OnlineAvailability | null {
 
 function mapRow(row: ApiService, availability: OnlineAvailability): Service {
   // Frontend label: external_service_name, or service_name as fallback.
-  const name = row.external_service_name?.trim() || row.service_name
+  const name = row.external_service_name?.trim() || row.service_name.trim()
 
   return {
     id: row.service_id,

--- a/appointment-booking/app/api/services.ts
+++ b/appointment-booking/app/api/services.ts
@@ -21,7 +21,6 @@ type ApiService = {
 
 type ApiServicesResponse = {
   services: ApiService[]
-  errors: Record<string, unknown>
 }
 
 function apiBaseUrl() {
@@ -69,11 +68,7 @@ function keepForPublicList(row: ApiService): OnlineAvailability | null {
   }
 
   const availability = readAvailability(row.online_availability)
-  if (availability === 'SHOW' || availability === 'DISABLE') {
-    return availability
-  }
-
-  return null
+  return availability
 }
 
 function mapRow(row: ApiService, availability: OnlineAvailability): Service {

--- a/appointment-booking/package-lock.json
+++ b/appointment-booking/package-lock.json
@@ -48,6 +48,7 @@
       "resolved": "https://registry.npmjs.org/@adobe/react-spectrum/-/react-spectrum-3.47.2.tgz",
       "integrity": "sha512-QxsE7bPBGpzwYofACF0RAL/Zs3p0u9HNvCDf9LEN87rEGFpkagIB+T+TSZ0xbl6BJ6z7S02m3zAFk3s9FoHJpQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@internationalized/date": "^3.12.2",
         "@react-types/shared": "^3.36.0",
@@ -136,6 +137,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -581,7 +583,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@bcgov/bc-sans/-/bc-sans-2.1.0.tgz",
       "integrity": "sha512-1MesF4NAVpM5dywoJ68wNcBylHbPqg1dDV/FNuQm0BbspETGlPmfX8LG8rtrCjCAPhWuL2qRT/lBYDUMvFTUnw==",
-      "license": "SIL"
+      "license": "SIL",
+      "peer": true
     },
     "node_modules/@bcgov/design-system-react-components": {
       "version": "0.7.0",
@@ -613,31 +616,6 @@
       "integrity": "sha512-kcen18Q/snP6M6JQ6XUQTlWXM1Gnm6y8Zk0i29K+T/Y0m/ab4PufmGpl43l/EJKCnYgpOaZFSXDK7CCO6P0INw==",
       "license": "Apache-2.0"
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -645,7 +623,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -830,6 +807,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.0.tgz",
       "integrity": "sha512-MFbTNLDWkLJwbozDvHOZ7hwyDjQcBMBattlcOQ6ZmV5YD9bBrqdl1rNtmVjQ/lzqveXXX3sMz2Ew6fAgXoxmkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.3.0"
       },
@@ -1435,6 +1413,7 @@
       "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-8.0.0.tgz",
       "integrity": "sha512-8nDp5pQCb3eY47/BabfH3SdMTWJIz69YmNWXGi6IWe9AE+qKdwyWNUc6aY1Jx8wnVQ833mj0v0fkpl+1hkBVxg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@react-router/express": "8.0.0",
         "@react-router/node": "8.0.0",
@@ -2177,6 +2156,7 @@
       "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2187,6 +2167,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2236,6 +2217,7 @@
       "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.1",
         "@typescript-eslint/types": "8.61.1",
@@ -2469,6 +2451,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2676,6 +2659,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3165,6 +3149,7 @@
       "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3224,6 +3209,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -3454,6 +3440,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -4921,6 +4908,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4985,6 +4973,7 @@
       "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5092,6 +5081,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5163,6 +5153,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5185,6 +5176,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.0.0.tgz",
       "integrity": "sha512-AyS7LUn9M3g2/IBJDJNpWqElaQjPVBHGgMsdLGee6B2JLwP9STSpRwN8N4SauOeFTb0X5ZN0wxa1Iek78jF8Iw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie-es": "^3.1.1"
       },
@@ -5830,6 +5822,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5976,6 +5969,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6106,6 +6100,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
### PR Testing Steps
Adds app/api/services.ts — fetches GET /api/v1/services/ and filters to the public list. No UI yet.

**Setup**
```
docker compose up -d db keycloak
cd api
uv run python manage.py db upgrade
uv run python manage.py bootstrap
```
**Start API (new terminal):**

```
cd api
uv run gunicorn wsgi --bind=0.0.0.0:5000 --access-logfile=- --config=gunicorn_config.py --reload --timeout=0
```
**Check API:** 

`curl -s -o /dev/null -w "HTTP %{http_code}\n" http://localhost:5000/api/v1/services/`

Should return HTTP 200

**Seed test data (local only)**
Fresh bootstrap returns results from getPublicServices() becuase online_availability isn't set on any seed services data
**Run once after bootstrap:**

```
docker compose exec db psql -U postgres -d postgres -c "
UPDATE service SET online_availability = 'SHOW',
  external_service_name = 'Medical Services Plan Application for BC Medical'
WHERE service_code = 'MSP - 001';
UPDATE service SET online_availability = 'DISABLE',
  external_service_name = 'BC Services Card - Non-photo Card'
WHERE service_code = 'MSP - 002';
UPDATE service SET online_availability = 'SHOW',
  external_service_name = 'Rural Property Tax - Deferment Application'
WHERE service_code = 'PTAX - 001';
"
```
**Run the client**
Create .env.local in appointment-booking/:

VITE_Q_API_URL=http://localhost:5000/api/v1


```
cd appointment-booking
printf '%s\n' \
  "import { getPublicServices } from './app/api/services.ts'" \
  "getPublicServices().then((s) => console.log(JSON.stringify(s, null, 2)))" \
  > .check-services.tmp.ts
npx vite-node .check-services.tmp.ts
rm .check-services.tmp.ts
```
**Expected**
3 services back:

MSP - 001 → SHOW, bookable
PTAX - 001 → SHOW, bookable
MSP - 002 → DISABLE, not bookable
HIDE, null availability, and display_dashboard_ind = 0 should be filtered out.

Optional raw API check: 
`curl -s http://localhost:5000/api/v1/services/ | python3 -m json.tool`