### PR TITLE
Fix empty exam PUT request causing 415

### DIFF
--- a/frontend/src/components/Booking/booking-modal.vue
+++ b/frontend/src/components/Booking/booking-modal.vue
@@ -517,7 +517,7 @@ export default class BookingModal extends Vue {
         if (this.exam.referrer === 'inventory') {
           redirect = true
         }
-        this.putRequest(payload).then(() => {
+        const finish = () => {
           this.getExams().then(() => {
             this.getBookings().then(() => {
               this.finishBooking()
@@ -526,7 +526,16 @@ export default class BookingModal extends Vue {
               }
             })
           })
-        })
+        }
+
+        if (putNotes) {
+          this.putRequest({
+            url: `/exams/${exam_id}/`,
+            data: { notes }
+          }).then(finish)
+        } else {
+          finish()
+        }
         this.booking_contact_information = ''
       })
     } else {


### PR DESCRIPTION
fixing the exam bug where an empty "Notes" section while scheduling will result in a second empty  "put" resulting in a 415 error.
"{ "message": "Did not attempt to load JSON data because the request Content-Type was not 'application/json'." }"

this is the result of upgrade in api/requirements.txt / pyproject.toml

flask==3.1.3
werkzeug==3.1.7

In Flask 3.x, request.get_json() is stricter. If the request does not have Content-Type: application/json, Flask returns 415 Unsupported Media Type

