### PR TITLE
Persist selected service in shared booking context for later steps.

### DIFF
--- a/appointment-booking/app/booking/booking-context.tsx
+++ b/appointment-booking/app/booking/booking-context.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useState, type ReactNode } from 'react'
+
+import type { Service } from '../api/services'
+
+// Booking-flow state shared across steps (in-memory; not page-refresh persistent).
+// Mounted once in root so selection survives navigation between booking steps.
+type BookingContextValue = {
+  // Full service object so later steps can use id/name/bookable without re-fetching.
+  selectedService: Service | null
+  setSelectedService: (service: Service | null) => void
+}
+
+const BookingContext = createContext<BookingContextValue | null>(null)
+
+// Owns booking selections for the SPA session. Step pages remount; this provider does not.
+export function BookingProvider({ children }: { children: ReactNode }) {
+  const [selectedService, setSelectedService] = useState<Service | null>(null)
+
+  return (
+    <BookingContext.Provider value={{ selectedService, setSelectedService }}>
+      {children}
+    </BookingContext.Provider>
+  )
+}
+
+// Used by booking step pages (services now; location/time/etc. later).
+export function useBooking() {
+  const value = useContext(BookingContext)
+  if (!value) {
+    throw new Error('useBooking must be used within BookingProvider')
+  }
+  return value
+}

--- a/appointment-booking/app/root.tsx
+++ b/appointment-booking/app/root.tsx
@@ -3,6 +3,7 @@ import { config } from '@fortawesome/fontawesome-svg-core'
 import { isRouteErrorResponse, Links, Meta, Outlet, Scripts, ScrollRestoration } from 'react-router'
 
 import type { Route } from './+types/root'
+import { BookingProvider } from './booking/booking-context'
 import '@bcgov/design-tokens/css/variables.css'
 import '@bcgov/bc-sans/css/BC_Sans.css'
 import './bcds-shell.css'
@@ -41,7 +42,10 @@ export default function App() {
         ]}
       />
       <main id="main-content" className="layout-main">
-        <Outlet />
+        {/* Keeps booking selection alive while navigating between booking steps. */}
+        <BookingProvider>
+          <Outlet />
+        </BookingProvider>
       </main>
       <Footer />
     </>

--- a/appointment-booking/app/routes/services.tsx
+++ b/appointment-booking/app/routes/services.tsx
@@ -8,6 +8,7 @@ import {
   TextField,
 } from '@bcgov/design-system-react-components'
 import { getPublicServices, type Service } from '../api/services'
+import { useBooking } from '../booking/booking-context'
 
 const BOOKING_STEP = 1
 const BOOKING_STEP_COUNT = 5
@@ -31,10 +32,13 @@ function getRowClassName(service: Service, selectedId: string) {
 }
 
 export default function ServicesPage() {
+  // Selection lives in booking context so later steps can reuse it.
+  const { selectedService, setSelectedService } = useBooking()
+  const selectedId = selectedService ? String(selectedService.id) : ''
+
   const [services, setServices] = useState<Service[]>([])
   const [isLoading, setIsLoading] = useState(true)
   const [loadError, setLoadError] = useState(false)
-  const [selectedId, setSelectedId] = useState('')
   const [search, setSearch] = useState('')
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
 
@@ -91,11 +95,10 @@ export default function ServicesPage() {
 
     if (nextIdx >= 0 && nextIdx < bookable.length) {
       e.preventDefault()
-      setSelectedId(String(bookable[nextIdx].id))
+      setSelectedService(bookable[nextIdx])
     }
   }
 
-  const selectedService = services.find((service) => String(service.id) === selectedId)
   const canContinue = !!selectedService?.isOnlineBookable
   const hasUnavailableServices = services.some((service) => !service.isOnlineBookable)
   const showLoadError = !isLoading && loadError
@@ -195,7 +198,7 @@ export default function ServicesPage() {
                         key={service.id}
                         className={getRowClassName(service, selectedId)}
                         onClick={() => {
-                          if (service.isOnlineBookable) setSelectedId(id)
+                          if (service.isOnlineBookable) setSelectedService(service)
                         }}
                         onKeyDown={handleRowKeyDown}
                         role="radio"

--- a/appointment-booking/eslint.config.js
+++ b/appointment-booking/eslint.config.js
@@ -29,7 +29,7 @@ export default defineConfig([
     },
   },
   {
-    files: ['app/routes/**/*.{ts,tsx}', 'app/root.tsx'],
+    files: ['app/routes/**/*.{ts,tsx}', 'app/root.tsx', 'app/booking/**/*.{ts,tsx}'],
     rules: {
       'react-refresh/only-export-components': 'off',
     },


### PR DESCRIPTION
### Summary
Added shared booking context for the selected service
Updated the services page to read/update that selection
Kept selection in memory across booking step navigation
### Test plan

-  Select a service, navigate away and back, selection remains
-  Refresh the page, selection resets (expected)