### PR TITLE
Refactored Services and locations page

### DIFF
--- a/appointment-booking/app/app.css
+++ b/appointment-booking/app/app.css
@@ -183,17 +183,17 @@ p {
   margin: 0;
 }
 
-.services-booking-progress {
+.booking-step-progress {
   margin-bottom: var(--layout-padding-xlarge);
 }
 
-.services-booking-step-count {
+.booking-step-count {
   margin: 0 0 var(--layout-padding-xsmall);
   font: var(--typography-bold-small-body);
   color: var(--typography-color-secondary);
 }
 
-.services-booking-step {
+.booking-step-heading {
   margin: 0 0 var(--layout-padding-small);
   font: var(--typography-bold-body);
 }

--- a/appointment-booking/app/bcds-shell.css
+++ b/appointment-booking/app/bcds-shell.css
@@ -38,9 +38,7 @@
   padding: var(--layout-padding-xlarge);
 }
 
-.bcds-footer
-  > .bcds-footer--acknowledgement
-  > .bcds-footer--acknowledgement-text {
+.bcds-footer > .bcds-footer--acknowledgement > .bcds-footer--acknowledgement-text {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -51,10 +49,7 @@
   width: 100%;
 }
 
-.bcds-footer
-  > .bcds-footer--acknowledgement
-  > .bcds-footer--acknowledgement-text
-  > p {
+.bcds-footer > .bcds-footer--acknowledgement > .bcds-footer--acknowledgement-text > p {
   margin: var(--layout-margin-none);
 }
 
@@ -388,11 +383,7 @@ p.bcds-footer--copyright {
 }
 
 .bcds-header > .bcds-header--container > ul.bcds-header--skiplinks li a:focus,
-.bcds-header
-  > .bcds-header--container
-  > ul.bcds-header--skiplinks
-  li
-  button:focus {
+.bcds-header > .bcds-header--container > ul.bcds-header--skiplinks li button:focus {
   margin-left: 0; /* Line up left edge with left edge of logo image */
   text-wrap: nowrap;
 }

--- a/appointment-booking/app/components/BookingContinueRow.tsx
+++ b/appointment-booking/app/components/BookingContinueRow.tsx
@@ -1,0 +1,16 @@
+import { Button } from '@bcgov/design-system-react-components'
+
+// Shared Continue button for booking steps. Enablement is decided by the calling page.
+type BookingContinueRowProps = {
+  isDisabled?: boolean
+}
+
+export function BookingContinueRow({ isDisabled = false }: BookingContinueRowProps) {
+  return (
+    <div className="booking-continue-row">
+      <Button variant="primary" size="medium" isDisabled={isDisabled}>
+        Continue
+      </Button>
+    </div>
+  )
+}

--- a/appointment-booking/app/components/BookingStepProgress.tsx
+++ b/appointment-booking/app/components/BookingStepProgress.tsx
@@ -1,0 +1,23 @@
+import { ProgressBar } from '@bcgov/design-system-react-components'
+
+// Shared step progress header for booking steps. Step number and heading come from the page.
+type BookingStepProgressProps = {
+  step: number
+  stepCount: number
+  heading: string
+}
+
+export function BookingStepProgress({ step, stepCount, heading }: BookingStepProgressProps) {
+  return (
+    <div className="booking-step-progress">
+      <p className="booking-step-count">
+        Step {step} of {stepCount}
+      </p>
+      <p className="booking-step-heading">{heading}</p>
+      <ProgressBar
+        value={(step / stepCount) * 100}
+        aria-label={`Step ${step} of ${stepCount}. ${heading}`}
+      />
+    </div>
+  )
+}

--- a/appointment-booking/app/components/LocationsSearch.tsx
+++ b/appointment-booking/app/components/LocationsSearch.tsx
@@ -1,0 +1,88 @@
+import { Button, TextField, Tooltip, TooltipTrigger } from '@bcgov/design-system-react-components'
+import { faLocationDot } from '@fortawesome/free-solid-svg-icons'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+
+export type NearestLocationStatus = 'idle' | 'loading' | 'active' | 'error'
+
+type LocationsSearchProps = {
+  value: string
+  onChange: (value: string) => void
+  onClear: () => void
+  // Page owns geolocation; this component only renders pin state and click.
+  nearestSort: boolean
+  nearestStatus: NearestLocationStatus
+  onNearestSortPress: () => void
+  ariaLabel?: string
+  placeholder?: string
+}
+
+function nearestSortTooltipText(isActive: boolean, status: NearestLocationStatus) {
+  if (status === 'loading') {
+    return 'Finding your location...'
+  }
+
+  if (isActive) {
+    return 'Nearest sort is on. Click to turn off.'
+  }
+
+  return 'Use your location to sort offices by distance.'
+}
+
+// Shared location search bar (directory + booking step 2): search, clear, nearest pin.
+export function LocationsSearch({
+  value,
+  onChange,
+  onClear,
+  nearestSort,
+  nearestStatus,
+  onNearestSortPress,
+  ariaLabel = 'Search locations',
+  placeholder = 'Search locations',
+}: LocationsSearchProps) {
+  const isLoading = nearestStatus === 'loading'
+
+  return (
+    <div className="locations-search-row">
+      <TextField
+        className="locations-search"
+        name="location-search"
+        value={value}
+        onChange={onChange}
+        aria-label={ariaLabel}
+        iconRight={
+          <TooltipTrigger>
+            <Button
+              className={
+                nearestSort ? 'locations-nearest-button is-active' : 'locations-nearest-button'
+              }
+              variant={nearestSort ? 'primary' : 'secondary'}
+              size="medium"
+              isIconButton
+              onPress={onNearestSortPress}
+              isDisabled={isLoading}
+              aria-pressed={nearestSort}
+              aria-label={
+                isLoading
+                  ? 'Finding your location'
+                  : nearestSort
+                    ? 'Clear nearest sort'
+                    : 'Sort offices by nearest to you'
+              }
+            >
+              <FontAwesomeIcon icon={faLocationDot} className="locations-pin-icon" />
+            </Button>
+            <Tooltip>{nearestSortTooltipText(nearestSort, nearestStatus)}</Tooltip>
+          </TooltipTrigger>
+        }
+        // @ts-expect-error placeholder is supported by underlying react-aria TextField
+        placeholder={placeholder}
+      />
+      {nearestSort ? <span className="locations-nearest-label">Nearest first</span> : null}
+      {value.trim() ? (
+        <Button variant="secondary" size="medium" onPress={onClear}>
+          Clear search
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/appointment-booking/app/components/ServicesSearch.tsx
+++ b/appointment-booking/app/components/ServicesSearch.tsx
@@ -1,0 +1,29 @@
+import { Button, TextField } from '@bcgov/design-system-react-components'
+
+// Presentational search row; the page owns the search string and filtering.
+type ServicesSearchProps = {
+  value: string
+  onChange: (value: string) => void
+  onClear: () => void
+}
+
+export function ServicesSearch({ value, onChange, onClear }: ServicesSearchProps) {
+  return (
+    <div className="services-search-row">
+      <TextField
+        className="services-search"
+        name="service-search"
+        value={value}
+        onChange={onChange}
+        aria-label="Search services"
+        // @ts-expect-error placeholder is supported by underlying react-aria TextField
+        placeholder="Search services"
+      />
+      {value.trim() ? (
+        <Button variant="secondary" size="medium" onPress={onClear}>
+          Clear search
+        </Button>
+      ) : null}
+    </div>
+  )
+}

--- a/appointment-booking/app/components/ServicesTable.tsx
+++ b/appointment-booking/app/components/ServicesTable.tsx
@@ -1,0 +1,119 @@
+import { SvgChevronDownIcon, SvgChevronUpIcon } from '@bcgov/design-system-react-components'
+import type { KeyboardEvent } from 'react'
+import type { Service } from '../api/services'
+
+type SortDirection = 'asc' | 'desc'
+
+// Presentational table: page owns fetch/filter/sort state, selection, and keyboard navigation.
+type ServicesTableProps = {
+  services: Service[]
+  isLoading: boolean
+  showNoResults: boolean
+  sortDirection: SortDirection
+  onToggleSort: () => void
+  selectedId: string
+  onSelect: (service: Service) => void
+  onRowKeyDown: (e: KeyboardEvent<HTMLTableRowElement>) => void
+}
+
+function getRowClassName(service: Service, selectedId: string) {
+  if (!service.isOnlineBookable) {
+    return 'is-unavailable'
+  }
+  if (String(service.id) === selectedId) {
+    return 'is-selected'
+  }
+  return ''
+}
+
+export function ServicesTable({
+  services,
+  isLoading,
+  showNoResults,
+  sortDirection,
+  onToggleSort,
+  selectedId,
+  onSelect,
+  onRowKeyDown,
+}: ServicesTableProps) {
+  return (
+    <div className="services-table-wrapper">
+      <table className="services-table">
+        <thead>
+          <tr>
+            <th scope="col" className="services-table-select-heading" aria-label="Select" />
+            <th scope="col" aria-sort={sortDirection === 'asc' ? 'ascending' : 'descending'}>
+              <button
+                type="button"
+                className="services-sort-button"
+                onClick={onToggleSort}
+                aria-label={
+                  sortDirection === 'asc' ? 'Sort services Z to A' : 'Sort services A to Z'
+                }
+              >
+                <span>Services</span>
+                <span className="services-sort-icons" aria-hidden="true">
+                  <span className={sortDirection === 'asc' ? 'is-active' : undefined}>
+                    <SvgChevronUpIcon />
+                  </span>
+                  <span className={sortDirection === 'desc' ? 'is-active' : undefined}>
+                    <SvgChevronDownIcon />
+                  </span>
+                </span>
+              </button>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {isLoading ? (
+            <tr>
+              <td colSpan={2}>Loading services...</td>
+            </tr>
+          ) : showNoResults ? (
+            <tr>
+              <td colSpan={2}>
+                No services match your search. Try different keywords or clear the search to see all
+                services.
+              </td>
+            </tr>
+          ) : (
+            services.map((service) => {
+              const id = String(service.id)
+
+              return (
+                <tr
+                  key={service.id}
+                  className={getRowClassName(service, selectedId)}
+                  onClick={() => {
+                    // Unavailable services are shown but not selectable.
+                    if (service.isOnlineBookable) onSelect(service)
+                  }}
+                  onKeyDown={onRowKeyDown}
+                  role="radio"
+                  aria-checked={selectedId === id}
+                  // Only the selected row is in the tab order; arrows move selection.
+                  tabIndex={selectedId === id ? 0 : -1}
+                >
+                  <td className="services-table-select-cell">
+                    <input
+                      type="radio"
+                      name="service"
+                      className="services-table-radio"
+                      value={id}
+                      checked={selectedId === id}
+                      disabled={!service.isOnlineBookable}
+                      // Visual/a11y only; selection is handled on the row.
+                      readOnly
+                      aria-label={service.name}
+                    />
+                  </td>
+                  <td>{service.name}</td>
+                </tr>
+              )
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/appointment-booking/app/routes/locations.tsx
+++ b/appointment-booking/app/routes/locations.tsx
@@ -1821,6 +1821,7 @@ export default function Locations() {
           name="office-search"
           value={search}
           onChange={setSearch}
+          aria-label="Search offices"
           iconRight={
             <TooltipTrigger>
               <Button

--- a/appointment-booking/app/routes/locations.tsx
+++ b/appointment-booking/app/routes/locations.tsx
@@ -1,6 +1,4 @@
 import { useMemo, useState } from 'react'
-import { faLocationDot } from '@fortawesome/free-solid-svg-icons'
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { getDistance } from 'geolib'
 import {
   Button,
@@ -8,10 +6,8 @@ import {
   Link,
   SvgChevronDownIcon,
   SvgChevronUpIcon,
-  TextField,
-  Tooltip,
-  TooltipTrigger,
 } from '@bcgov/design-system-react-components'
+import { LocationsSearch } from '../components/LocationsSearch'
 
 const PAGE_DESCRIPTION =
   'Find Service BC office locations in British Columbia. View addresses, contact details, hours of operation and book an appointment.'
@@ -1656,21 +1652,6 @@ export function meta() {
   return [{ title: 'Service BC Locations' }, { name: 'description', content: PAGE_DESCRIPTION }]
 }
 
-function nearestTooltipText(
-  nearestSort: boolean,
-  locationStatus: 'idle' | 'loading' | 'active' | 'error',
-) {
-  if (locationStatus === 'loading') {
-    return 'Finding your location...'
-  }
-
-  if (nearestSort) {
-    return 'Nearest sort is on. Click to turn off.'
-  }
-
-  return 'Use your location to sort offices by distance.'
-}
-
 export default function Locations() {
   const [search, setSearch] = useState('')
   const [sortColumn, setSortColumn] = useState<SortColumn>('location')
@@ -1815,41 +1796,16 @@ export default function Locations() {
         offices by distance from you.
       </p>
 
-      <div className="locations-search-row">
-        <TextField
-          className="locations-search"
-          name="office-search"
-          value={search}
-          onChange={setSearch}
-          aria-label="Search offices"
-          iconRight={
-            <TooltipTrigger>
-              <Button
-                className={
-                  nearestSort ? 'locations-nearest-button is-active' : 'locations-nearest-button'
-                }
-                variant={nearestSort ? 'primary' : 'secondary'}
-                size="medium"
-                isIconButton
-                onPress={toggleNearestSort}
-                isDisabled={locationStatus === 'loading'}
-                aria-pressed={nearestSort}
-                aria-label={
-                  locationStatus === 'loading'
-                    ? 'Finding your location'
-                    : nearestSort
-                      ? 'Clear nearest sort'
-                      : 'Sort offices by nearest to you'
-                }
-              >
-                <LocationIcon />
-              </Button>
-              <Tooltip>{nearestTooltipText(nearestSort, locationStatus)}</Tooltip>
-            </TooltipTrigger>
-          }
-        />
-        {nearestSort ? <span className="locations-nearest-label">Nearest first</span> : null}
-      </div>
+      <LocationsSearch
+        value={search}
+        onChange={setSearch}
+        onClear={() => setSearch('')}
+        nearestSort={nearestSort}
+        nearestStatus={locationStatus}
+        onNearestSortPress={toggleNearestSort}
+        ariaLabel="Search offices"
+        placeholder="Search offices"
+      />
 
       {locationError ? (
         <InlineAlert variant="danger" title="Location unavailable">
@@ -1993,10 +1949,6 @@ export default function Locations() {
       </div>
     </>
   )
-}
-
-function LocationIcon() {
-  return <FontAwesomeIcon icon={faLocationDot} className="locations-pin-icon" />
 }
 
 function ColumnSortButton({

--- a/appointment-booking/app/routes/services.tsx
+++ b/appointment-booking/app/routes/services.tsx
@@ -1,14 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
-import {
-  Button,
-  InlineAlert,
-  ProgressBar,
-  SvgChevronDownIcon,
-  SvgChevronUpIcon,
-  TextField,
-} from '@bcgov/design-system-react-components'
+import { InlineAlert } from '@bcgov/design-system-react-components'
 import { getPublicServices, type Service } from '../api/services'
 import { useBooking } from '../booking/booking-context'
+import { BookingContinueRow } from '../components/BookingContinueRow'
+import { BookingStepProgress } from '../components/BookingStepProgress'
+import { ServicesSearch } from '../components/ServicesSearch'
+import { ServicesTable } from '../components/ServicesTable'
 
 const BOOKING_STEP = 1
 const BOOKING_STEP_COUNT = 5
@@ -19,16 +16,6 @@ type SortDirection = 'asc' | 'desc'
 
 export function meta() {
   return [{ title: 'Services' }]
-}
-
-function getRowClassName(service: Service, selectedId: string) {
-  if (!service.isOnlineBookable) {
-    return 'is-unavailable'
-  }
-  if (String(service.id) === selectedId) {
-    return 'is-selected'
-  }
-  return ''
 }
 
 export default function ServicesPage() {
@@ -99,6 +86,7 @@ export default function ServicesPage() {
     }
   }
 
+  // Page owns Continue enablement; only a bookable selection unlocks the next step.
   const canContinue = !!selectedService?.isOnlineBookable
   const hasUnavailableServices = services.some((service) => !service.isOnlineBookable)
   const showLoadError = !isLoading && loadError
@@ -109,16 +97,11 @@ export default function ServicesPage() {
     <>
       <h1 className="sr-only">Services</h1>
 
-      <div className="services-booking-progress">
-        <p className="services-booking-step-count">
-          Step {BOOKING_STEP} of {BOOKING_STEP_COUNT}
-        </p>
-        <p className="services-booking-step">{BOOKING_STEP_HEADING}</p>
-        <ProgressBar
-          value={(BOOKING_STEP / BOOKING_STEP_COUNT) * 100}
-          aria-label={`Step ${BOOKING_STEP} of ${BOOKING_STEP_COUNT}. ${BOOKING_STEP_HEADING}`}
-        />
-      </div>
+      <BookingStepProgress
+        step={BOOKING_STEP}
+        stepCount={BOOKING_STEP_COUNT}
+        heading={BOOKING_STEP_HEADING}
+      />
 
       {showLoadError ? (
         <InlineAlert variant="danger" title="Unable to load services">
@@ -131,100 +114,21 @@ export default function ServicesPage() {
       ) : (
         <>
           {!isLoading && (
-            <div className="services-search-row">
-              <TextField
-                className="services-search"
-                name="service-search"
-                value={search}
-                onChange={setSearch}
-                // @ts-expect-error placeholder is supported by underlying react-aria TextField
-                placeholder="Search services"
-              />
-              {search.trim() ? (
-                <Button variant="secondary" size="medium" onPress={() => setSearch('')}>
-                  Clear search
-                </Button>
-              ) : null}
-            </div>
+            <ServicesSearch value={search} onChange={setSearch} onClear={() => setSearch('')} />
           )}
 
-          <div className="services-table-wrapper">
-            <table className="services-table">
-              <thead>
-                <tr>
-                  <th scope="col" className="services-table-select-heading" aria-label="Select" />
-                  <th scope="col" aria-sort={sortDirection === 'asc' ? 'ascending' : 'descending'}>
-                    <button
-                      type="button"
-                      className="services-sort-button"
-                      onClick={() =>
-                        setSortDirection((direction) => (direction === 'asc' ? 'desc' : 'asc'))
-                      }
-                      aria-label={
-                        sortDirection === 'asc' ? 'Sort services Z to A' : 'Sort services A to Z'
-                      }
-                    >
-                      <span>Services</span>
-                      <span className="services-sort-icons" aria-hidden="true">
-                        <span className={sortDirection === 'asc' ? 'is-active' : undefined}>
-                          <SvgChevronUpIcon />
-                        </span>
-                        <span className={sortDirection === 'desc' ? 'is-active' : undefined}>
-                          <SvgChevronDownIcon />
-                        </span>
-                      </span>
-                    </button>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {isLoading ? (
-                  <tr>
-                    <td colSpan={2}>Loading services...</td>
-                  </tr>
-                ) : showNoResults ? (
-                  <tr>
-                    <td colSpan={2}>
-                      No services match your search. Try different keywords or clear the search to
-                      see all services.
-                    </td>
-                  </tr>
-                ) : (
-                  visibleServices.map((service) => {
-                    const id = String(service.id)
-
-                    return (
-                      <tr
-                        key={service.id}
-                        className={getRowClassName(service, selectedId)}
-                        onClick={() => {
-                          if (service.isOnlineBookable) setSelectedService(service)
-                        }}
-                        onKeyDown={handleRowKeyDown}
-                        role="radio"
-                        aria-checked={selectedId === id}
-                        tabIndex={selectedId === id ? 0 : -1}
-                      >
-                        <td className="services-table-select-cell">
-                          <input
-                            type="radio"
-                            name="service"
-                            className="services-table-radio"
-                            value={id}
-                            checked={selectedId === id}
-                            disabled={!service.isOnlineBookable}
-                            readOnly
-                            aria-label={service.name}
-                          />
-                        </td>
-                        <td>{service.name}</td>
-                      </tr>
-                    )
-                  })
-                )}
-              </tbody>
-            </table>
-          </div>
+          <ServicesTable
+            services={visibleServices}
+            isLoading={isLoading}
+            showNoResults={showNoResults}
+            sortDirection={sortDirection}
+            onToggleSort={() =>
+              setSortDirection((direction) => (direction === 'asc' ? 'desc' : 'asc'))
+            }
+            selectedId={selectedId}
+            onSelect={setSelectedService}
+            onRowKeyDown={handleRowKeyDown}
+          />
 
           {!isLoading && hasUnavailableServices && (
             <p className="services-table-note">
@@ -234,11 +138,7 @@ export default function ServicesPage() {
         </>
       )}
 
-      <div className="booking-continue-row">
-        <Button variant="primary" size="medium" isDisabled={!canContinue}>
-          Continue
-        </Button>
-      </div>
+      <BookingContinueRow isDisabled={!canContinue} />
     </>
   )
 }


### PR DESCRIPTION
### Summary

- Thin ServicesPage into a container; extract ServicesSearch, ServicesTable, BookingStepProgress, and BookingContinueRow
- Page still owns fetch, search/sort, selection, keyboard nav, and Continue enablement
- Add aria-label on Services/Locations search fields; Prettier-fix bcds-shell.css