### PR TITLE
added service locations page with table to show locations

### DIFF
--- a/appointment-booking/app/api/locations.ts
+++ b/appointment-booking/app/api/locations.ts
@@ -1,0 +1,63 @@
+import { getApiBaseUrl } from '../runtime-config'
+
+// Location type used by the booking flow after mapping from the offices API.
+export type Location = {
+  id: number
+  name: string
+  address: string
+  latitude: number | null
+  longitude: number | null
+}
+
+// API response row from GET /api/v1/offices/.
+type ApiOffice = {
+  office_id: number
+  office_name: string
+  civic_address: string | null
+  latitude: number | null
+  longitude: number | null
+  appointments_enabled_ind: number
+  online_status: string | null
+  deleted: string | null
+}
+
+type ApiOfficesResponse = {
+  offices: ApiOffice[]
+}
+
+// Fetch bookable offices for the booking locations step.
+// Throws on fetch/HTTP/parse failure so the page can tell error apart from empty [].
+export async function getBookingLocations(): Promise<Location[]> {
+  const url = `${await getApiBaseUrl()}/offices/`
+
+  let body: ApiOfficesResponse
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error('Failed to load locations')
+    }
+    body = (await response.json()) as ApiOfficesResponse
+  } catch {
+    throw new Error('Failed to load locations')
+  }
+
+  const locations: Location[] = []
+
+  for (const row of body.offices ?? []) {
+    const status = row.online_status ?? ''
+    const isShow = status === 'SHOW' || status.endsWith('.SHOW')
+    if (row.deleted || !row.appointments_enabled_ind || !isShow) {
+      continue
+    }
+
+    locations.push({
+      id: row.office_id,
+      name: row.office_name.trim(),
+      address: row.civic_address?.trim() || '',
+      latitude: row.latitude,
+      longitude: row.longitude,
+    })
+  }
+
+  return locations
+}

--- a/appointment-booking/app/app.css
+++ b/appointment-booking/app/app.css
@@ -365,10 +365,47 @@ p {
   color: var(--typography-color-secondary);
 }
 
+.booking-selected-service {
+  margin: 0 0 var(--layout-padding-xlarge);
+  padding: var(--layout-padding-medium) var(--layout-padding-large);
+  font: var(--typography-regular-body);
+  color: var(--typography-color-primary);
+  background: var(--theme-blue-10);
+  border-left: var(--layout-border-width-medium) solid var(--theme-blue-80);
+  border-radius: var(--layout-border-radius-medium);
+}
+
+.booking-selected-service strong {
+  font: var(--typography-bold-body);
+}
+
+.services-table-name-cell,
+.services-table-address-cell {
+  word-break: break-word;
+  vertical-align: top;
+}
+
+.services-table-name-cell {
+  width: 42%;
+}
+
+.booking-nav-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--layout-padding-medium);
+  margin-top: var(--layout-padding-large);
+}
+
 .booking-continue-row {
   margin-top: var(--layout-padding-large);
   margin-left: auto;
   width: fit-content;
+}
+
+.booking-nav-row .booking-continue-row {
+  margin-top: 0;
+  margin-left: 0;
 }
 
 @media (max-width: 48rem) {
@@ -433,6 +470,8 @@ p {
     text-align: center;
   }
 
+  .services-table-name-cell,
+  .services-table-address-cell,
   .services-table td:last-child {
     flex: 1;
     min-width: 0;

--- a/appointment-booking/app/app.css
+++ b/appointment-booking/app/app.css
@@ -35,7 +35,8 @@ p {
 }
 
 /* Locations directory table — BC DS has no Table component, so we style our own */
-.locations-search-row {
+.locations-search-row,
+.services-search-row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
@@ -46,6 +47,12 @@ p {
 .locations-search {
   flex: 1 1 16rem;
   max-width: 32rem;
+  margin-bottom: 0;
+}
+
+.services-search {
+  flex: 1 1 16rem;
+  max-width: 24rem;
   margin-bottom: 0;
 }
 
@@ -94,12 +101,11 @@ p {
   background: var(--surface-color-background-white);
 }
 
-.locations-sort-button {
+.locations-sort-button,
+.services-sort-button {
   display: inline-flex;
   align-items: center;
-  justify-content: space-between;
   gap: var(--layout-margin-small);
-  width: 100%;
   padding: 0;
   border: none;
   background: none;
@@ -109,32 +115,42 @@ p {
   cursor: pointer;
 }
 
-.locations-sort-icons {
+.locations-sort-button {
+  justify-content: space-between;
+  width: 100%;
+}
+
+.locations-sort-icons,
+.services-sort-icons {
   display: inline-flex;
   flex-direction: column;
   flex-shrink: 0;
   line-height: 0;
 }
 
-.locations-sort-icons svg {
+.locations-sort-icons svg,
+.services-sort-icons svg {
   width: 0.75rem;
   height: 0.75rem;
   color: var(--typography-color-secondary);
   opacity: 0.45;
 }
 
-.locations-sort-icons .is-active svg {
+.locations-sort-icons .is-active svg,
+.services-sort-icons .is-active svg {
   color: var(--typography-color-primary);
   opacity: 1;
 }
 
-.locations-sort-button:hover {
+.locations-sort-button:hover,
+.services-sort-button:hover {
   color: var(--typography-color-link);
 }
 
-.locations-sort-button:focus-visible {
-  outline: solid var(--layout-border-width-medium) var(--surface-color-border-active);
-  outline-offset: var(--layout-margin-hair);
+.locations-sort-button:focus-visible,
+.services-sort-button:focus-visible {
+  outline: var(--layout-border-width-medium) solid var(--surface-color-border-active);
+  outline-offset: var(--layout-padding-xsmall);
 }
 
 .locations-table tbody tr:nth-child(even) {
@@ -198,61 +214,6 @@ p {
   font: var(--typography-bold-body);
 }
 
-.services-search-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--layout-padding-medium);
-  margin-bottom: var(--layout-padding-xlarge);
-}
-
-.services-search {
-  flex: 1 1 16rem;
-  max-width: 24rem;
-  margin-bottom: 0;
-}
-
-.services-sort-button {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--layout-margin-small);
-  padding: 0;
-  border: none;
-  background: none;
-  font: inherit;
-  color: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
-.services-sort-icons {
-  display: inline-flex;
-  flex-direction: column;
-  flex-shrink: 0;
-  line-height: 0;
-}
-
-.services-sort-icons svg {
-  width: 0.75rem;
-  height: 0.75rem;
-  color: var(--typography-color-secondary);
-  opacity: 0.45;
-}
-
-.services-sort-icons .is-active svg {
-  color: var(--typography-color-primary);
-  opacity: 1;
-}
-
-.services-sort-button:hover {
-  color: var(--typography-color-link);
-}
-
-.services-sort-button:focus-visible {
-  outline: var(--layout-border-width-medium) solid var(--surface-color-border-active);
-  outline-offset: var(--layout-padding-xsmall);
-}
-
 .sr-only {
   position: absolute;
   width: 1px;
@@ -263,6 +224,13 @@ p {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+.services-table-fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
 }
 
 .services-table-wrapper {
@@ -315,22 +283,18 @@ p {
   background: var(--surface-color-background-white);
 }
 
-.services-table tbody tr:not(.is-unavailable) {
-  cursor: pointer;
-}
-
-.services-table tbody tr.is-selected {
+.services-table tbody tr:has(input[type='radio']:checked:not(:disabled)) {
   background: var(--theme-blue-10);
   box-shadow: inset var(--layout-border-width-medium) 0 0 0 var(--theme-blue-80);
 }
 
 .services-table tbody tr.is-unavailable {
   color: var(--typography-color-disabled);
-  cursor: not-allowed;
 }
 
-.services-table tbody tr.is-unavailable .services-table-radio:disabled {
+.services-table tbody tr.is-unavailable input[type='radio']:disabled {
   opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .services-table-select-cell {
@@ -340,18 +304,16 @@ p {
   padding-top: calc(var(--layout-padding-medium) + 0.125rem);
 }
 
-.services-table-radio {
-  width: 1.25rem;
-  height: 1.25rem;
+.services-table-select-cell input[type='radio'] {
   margin: 0;
   accent-color: var(--theme-blue-80);
   cursor: pointer;
-  display: block;
-  margin-inline: auto;
 }
 
-.services-table-radio:disabled {
-  cursor: not-allowed;
+.services-table label {
+  display: block;
+  margin: 0;
+  cursor: pointer;
 }
 
 .services-table td:last-child {
@@ -363,30 +325,6 @@ p {
   margin: var(--layout-padding-medium) 0 0;
   font: var(--typography-regular-small-body);
   color: var(--typography-color-secondary);
-}
-
-.booking-selected-service {
-  margin: 0 0 var(--layout-padding-xlarge);
-  padding: var(--layout-padding-medium) var(--layout-padding-large);
-  font: var(--typography-regular-body);
-  color: var(--typography-color-primary);
-  background: var(--theme-blue-10);
-  border-left: var(--layout-border-width-medium) solid var(--theme-blue-80);
-  border-radius: var(--layout-border-radius-medium);
-}
-
-.booking-selected-service strong {
-  font: var(--typography-bold-body);
-}
-
-.services-table-name-cell,
-.services-table-address-cell {
-  word-break: break-word;
-  vertical-align: top;
-}
-
-.services-table-name-cell {
-  width: 42%;
 }
 
 .booking-nav-row {
@@ -406,6 +344,64 @@ p {
 .booking-nav-row .booking-continue-row {
   margin-top: 0;
   margin-left: 0;
+}
+
+.booking-locations-layout {
+  display: flex;
+  flex-direction: column;
+  gap: var(--layout-padding-xlarge);
+}
+
+.booking-locations-layout .locations-search-row {
+  margin-bottom: 0;
+}
+
+.booking-locations-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--layout-padding-xlarge);
+  min-width: 0;
+}
+
+.booking-locations-layout .locations-search {
+  flex: 1 1 100%;
+  max-width: none;
+  width: 100%;
+}
+
+.booking-locations-detail {
+  min-width: 0;
+  order: 1;
+}
+
+.booking-locations-body > .services-table-fieldset {
+  min-width: 0;
+  order: 2;
+}
+
+@media (min-width: 48rem) {
+  .booking-locations-layout > .locations-search-row {
+    width: calc((100% - var(--layout-padding-xlarge)) / 2);
+  }
+
+  .booking-locations-body {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+
+  .booking-locations-body > .services-table-fieldset,
+  .booking-locations-detail {
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .booking-locations-detail {
+    order: 2;
+  }
+
+  .booking-locations-body > .services-table-fieldset {
+    order: 1;
+  }
 }
 
 @media (max-width: 48rem) {
@@ -470,8 +466,6 @@ p {
     text-align: center;
   }
 
-  .services-table-name-cell,
-  .services-table-address-cell,
   .services-table td:last-child {
     flex: 1;
     min-width: 0;

--- a/appointment-booking/app/booking/booking-context.tsx
+++ b/appointment-booking/app/booking/booking-context.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, type ReactNode } from 'react'
 
+import type { Location } from '../api/locations'
 import type { Service } from '../api/services'
 
 // Booking-flow state shared across steps (in-memory; not page-refresh persistent).
@@ -8,6 +9,9 @@ type BookingContextValue = {
   // Full service object so later steps can use id/name/bookable without re-fetching.
   selectedService: Service | null
   setSelectedService: (service: Service | null) => void
+  // Full location object so later steps can use id/name/address without re-fetching.
+  selectedLocation: Location | null
+  setSelectedLocation: (location: Location | null) => void
 }
 
 const BookingContext = createContext<BookingContextValue | null>(null)
@@ -15,15 +19,18 @@ const BookingContext = createContext<BookingContextValue | null>(null)
 // Owns booking selections for the SPA session. Step pages remount; this provider does not.
 export function BookingProvider({ children }: { children: ReactNode }) {
   const [selectedService, setSelectedService] = useState<Service | null>(null)
+  const [selectedLocation, setSelectedLocation] = useState<Location | null>(null)
 
   return (
-    <BookingContext.Provider value={{ selectedService, setSelectedService }}>
+    <BookingContext.Provider
+      value={{ selectedService, setSelectedService, selectedLocation, setSelectedLocation }}
+    >
       {children}
     </BookingContext.Provider>
   )
 }
 
-// Used by booking step pages (services now; location/time/etc. later).
+// Used by booking step pages (services, locations; time/etc. later).
 export function useBooking() {
   const value = useContext(BookingContext)
   if (!value) {

--- a/appointment-booking/app/components/BookingBackRow.tsx
+++ b/appointment-booking/app/components/BookingBackRow.tsx
@@ -1,0 +1,16 @@
+import { Button } from '@bcgov/design-system-react-components'
+
+// Shared Back button for booking steps after step 1. Navigation is decided by the calling page.
+type BookingBackRowProps = {
+  onBack: () => void
+}
+
+export function BookingBackRow({ onBack }: BookingBackRowProps) {
+  return (
+    <div className="booking-back-row">
+      <Button variant="secondary" size="medium" onPress={onBack}>
+        Back
+      </Button>
+    </div>
+  )
+}

--- a/appointment-booking/app/components/BookingContinueRow.tsx
+++ b/appointment-booking/app/components/BookingContinueRow.tsx
@@ -1,14 +1,15 @@
 import { Button } from '@bcgov/design-system-react-components'
 
-// Shared Continue button for booking steps. Enablement is decided by the calling page.
+// Shared Continue button for booking steps. Enablement and navigation are decided by the calling page.
 type BookingContinueRowProps = {
   isDisabled?: boolean
+  onContinue?: () => void
 }
 
-export function BookingContinueRow({ isDisabled = false }: BookingContinueRowProps) {
+export function BookingContinueRow({ isDisabled = false, onContinue }: BookingContinueRowProps) {
   return (
     <div className="booking-continue-row">
-      <Button variant="primary" size="medium" isDisabled={isDisabled}>
+      <Button variant="primary" size="medium" isDisabled={isDisabled} onPress={onContinue}>
         Continue
       </Button>
     </div>

--- a/appointment-booking/app/components/LocationsSearch.tsx
+++ b/appointment-booking/app/components/LocationsSearch.tsx
@@ -1,14 +1,18 @@
+import { useState } from 'react'
 import { Button, TextField, Tooltip, TooltipTrigger } from '@bcgov/design-system-react-components'
 import { faLocationDot } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 
+// Hook + search UI are one locations-search module (directory + booking step 2).
+/* eslint-disable react-refresh/only-export-components */
 export type NearestLocationStatus = 'idle' | 'loading' | 'active' | 'error'
+export type Coordinates = { latitude: number; longitude: number }
 
 type LocationsSearchProps = {
   value: string
   onChange: (value: string) => void
   onClear: () => void
-  // Page owns geolocation; this component only renders pin state and click.
+  // From useNearestSort — this component only renders pin state and click.
   nearestSort: boolean
   nearestStatus: NearestLocationStatus
   onNearestSortPress: () => void
@@ -26,6 +30,70 @@ function nearestSortTooltipText(isActive: boolean, status: NearestLocationStatus
   }
 
   return 'Use your location to sort offices by distance.'
+}
+
+// Shared geolocation + nearest-sort state for the directory and booking locations step.
+// LocationsSearch only renders the pin; pages use userLocation to sort their lists.
+export function useNearestSort() {
+  const [nearestSort, setNearestSort] = useState(false)
+  const [status, setStatus] = useState<NearestLocationStatus>('idle')
+  const [userLocation, setUserLocation] = useState<Coordinates | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  function clearNearestSort() {
+    setNearestSort(false)
+    setStatus('idle')
+    setUserLocation(null)
+    setError(null)
+  }
+
+  function toggleNearestSort() {
+    if (nearestSort) {
+      clearNearestSort()
+      return
+    }
+
+    // Guard for SSR / browsers without geolocation — pin must not throw.
+    if (typeof navigator === 'undefined' || !navigator.geolocation) {
+      setStatus('error')
+      setError('Your browser does not support location services.')
+      return
+    }
+
+    setStatus('loading')
+    setError(null)
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setUserLocation({
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        })
+        setNearestSort(true)
+        setStatus('active')
+      },
+      (geoError) => {
+        setStatus('error')
+        setNearestSort(false)
+        setUserLocation(null)
+        setError(
+          geoError.code === geoError.PERMISSION_DENIED
+            ? 'Location access was denied. Allow location in your browser to sort by nearest office.'
+            : 'Unable to determine your location. Please try again.',
+        )
+      },
+      { enableHighAccuracy: false, timeout: 10000, maximumAge: 300000 },
+    )
+  }
+
+  return {
+    nearestSort,
+    status,
+    userLocation,
+    error,
+    clearNearestSort,
+    toggleNearestSort,
+  }
 }
 
 // Shared location search bar (directory + booking step 2): search, clear, nearest pin.

--- a/appointment-booking/app/components/LocationsTable.tsx
+++ b/appointment-booking/app/components/LocationsTable.tsx
@@ -1,10 +1,8 @@
 import { SvgChevronDownIcon, SvgChevronUpIcon } from '@bcgov/design-system-react-components'
-import type { KeyboardEvent } from 'react'
 import type { Location } from '../api/locations'
 
 type SortDirection = 'asc' | 'desc'
 
-// Presentational table: page owns fetch/filter/sort state, selection, and keyboard navigation.
 type LocationsTableProps = {
   locations: Location[]
   isLoading: boolean
@@ -13,7 +11,6 @@ type LocationsTableProps = {
   onToggleSort: () => void
   selectedId: string
   onSelect: (location: Location) => void
-  onRowKeyDown: (e: KeyboardEvent<HTMLTableRowElement>) => void
 }
 
 export function LocationsTable({
@@ -24,84 +21,78 @@ export function LocationsTable({
   onToggleSort,
   selectedId,
   onSelect,
-  onRowKeyDown,
 }: LocationsTableProps) {
   return (
-    <div className="services-table-wrapper">
-      <table className="services-table">
-        <thead>
-          <tr>
-            <th scope="col" className="services-table-select-heading" aria-label="Select" />
-            <th scope="col" aria-sort={sortDirection === 'asc' ? 'ascending' : 'descending'}>
-              <button
-                type="button"
-                className="services-sort-button"
-                onClick={onToggleSort}
-                aria-label={
-                  sortDirection === 'asc' ? 'Sort locations Z to A' : 'Sort locations A to Z'
-                }
-              >
-                <span>Location</span>
-                <span className="services-sort-icons" aria-hidden="true">
-                  <span className={sortDirection === 'asc' ? 'is-active' : undefined}>
-                    <SvgChevronUpIcon />
-                  </span>
-                  <span className={sortDirection === 'desc' ? 'is-active' : undefined}>
-                    <SvgChevronDownIcon />
-                  </span>
-                </span>
-              </button>
-            </th>
-            <th scope="col">Address</th>
-          </tr>
-        </thead>
-        <tbody>
-          {isLoading ? (
+    <fieldset className="services-table-fieldset">
+      <legend className="sr-only">Select a location</legend>
+      <div className="services-table-wrapper">
+        <table className="services-table">
+          <thead>
             <tr>
-              <td colSpan={3}>Loading locations...</td>
-            </tr>
-          ) : showNoResults ? (
-            <tr>
-              <td colSpan={3}>
-                No locations match your search. Try different keywords or clear the search to see
-                all locations.
-              </td>
-            </tr>
-          ) : (
-            locations.map((location) => {
-              const id = String(location.id)
-
-              return (
-                <tr
-                  key={location.id}
-                  className={id === selectedId ? 'is-selected' : undefined}
-                  onClick={() => onSelect(location)}
-                  onKeyDown={onRowKeyDown}
-                  role="radio"
-                  aria-checked={selectedId === id}
-                  // Only the selected row is in the tab order; arrows move selection.
-                  tabIndex={selectedId === id ? 0 : -1}
+              <th scope="col" className="services-table-select-heading" aria-hidden="true" />
+              <th scope="col" aria-sort={sortDirection === 'asc' ? 'ascending' : 'descending'}>
+                <button
+                  type="button"
+                  className="services-sort-button"
+                  onClick={onToggleSort}
+                  aria-label={
+                    sortDirection === 'asc' ? 'Sort locations Z to A' : 'Sort locations A to Z'
+                  }
                 >
-                  <td className="services-table-select-cell">
-                    <input
-                      type="radio"
-                      name="location"
-                      className="services-table-radio"
-                      value={id}
-                      checked={selectedId === id}
-                      // Visual/a11y only; selection is handled on the row.
-                      readOnly
-                      aria-label={`${location.name}${location.address ? `, ${location.address}` : ''}`}
-                    />
-                  </td>
-                  <td className="services-table-name-cell">{location.name}</td>
-                  <td className="services-table-address-cell">{location.address || '—'}</td>
-                </tr>
-              )
-            })
-          )}
-        </tbody>
-      </table>
-    </div>
+                  <span>Location</span>
+                  <span className="services-sort-icons" aria-hidden="true">
+                    <span className={sortDirection === 'asc' ? 'is-active' : undefined}>
+                      <SvgChevronUpIcon />
+                    </span>
+                    <span className={sortDirection === 'desc' ? 'is-active' : undefined}>
+                      <SvgChevronDownIcon />
+                    </span>
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <tr>
+                <td colSpan={2}>Loading locations...</td>
+              </tr>
+            ) : showNoResults ? (
+              <tr>
+                <td colSpan={2}>
+                  No locations match your search. Try different keywords or clear the search to see
+                  all locations.
+                </td>
+              </tr>
+            ) : (
+              locations.map((location) => {
+                const inputId = `location-${location.id}`
+                const address = location.address || '—'
+
+                return (
+                  <tr key={location.id}>
+                    <td className="services-table-select-cell">
+                      <input
+                        type="radio"
+                        id={inputId}
+                        name="location"
+                        checked={selectedId === String(location.id)}
+                        onChange={() => onSelect(location)}
+                      />
+                    </td>
+                    <td>
+                      <label htmlFor={inputId}>
+                        {location.name}
+                        <span className="sr-only">, {address}</span>
+                      </label>
+                    </td>
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </fieldset>
   )
 }

--- a/appointment-booking/app/components/LocationsTable.tsx
+++ b/appointment-booking/app/components/LocationsTable.tsx
@@ -1,0 +1,107 @@
+import { SvgChevronDownIcon, SvgChevronUpIcon } from '@bcgov/design-system-react-components'
+import type { KeyboardEvent } from 'react'
+import type { Location } from '../api/locations'
+
+type SortDirection = 'asc' | 'desc'
+
+// Presentational table: page owns fetch/filter/sort state, selection, and keyboard navigation.
+type LocationsTableProps = {
+  locations: Location[]
+  isLoading: boolean
+  showNoResults: boolean
+  sortDirection: SortDirection
+  onToggleSort: () => void
+  selectedId: string
+  onSelect: (location: Location) => void
+  onRowKeyDown: (e: KeyboardEvent<HTMLTableRowElement>) => void
+}
+
+export function LocationsTable({
+  locations,
+  isLoading,
+  showNoResults,
+  sortDirection,
+  onToggleSort,
+  selectedId,
+  onSelect,
+  onRowKeyDown,
+}: LocationsTableProps) {
+  return (
+    <div className="services-table-wrapper">
+      <table className="services-table">
+        <thead>
+          <tr>
+            <th scope="col" className="services-table-select-heading" aria-label="Select" />
+            <th scope="col" aria-sort={sortDirection === 'asc' ? 'ascending' : 'descending'}>
+              <button
+                type="button"
+                className="services-sort-button"
+                onClick={onToggleSort}
+                aria-label={
+                  sortDirection === 'asc' ? 'Sort locations Z to A' : 'Sort locations A to Z'
+                }
+              >
+                <span>Location</span>
+                <span className="services-sort-icons" aria-hidden="true">
+                  <span className={sortDirection === 'asc' ? 'is-active' : undefined}>
+                    <SvgChevronUpIcon />
+                  </span>
+                  <span className={sortDirection === 'desc' ? 'is-active' : undefined}>
+                    <SvgChevronDownIcon />
+                  </span>
+                </span>
+              </button>
+            </th>
+            <th scope="col">Address</th>
+          </tr>
+        </thead>
+        <tbody>
+          {isLoading ? (
+            <tr>
+              <td colSpan={3}>Loading locations...</td>
+            </tr>
+          ) : showNoResults ? (
+            <tr>
+              <td colSpan={3}>
+                No locations match your search. Try different keywords or clear the search to see
+                all locations.
+              </td>
+            </tr>
+          ) : (
+            locations.map((location) => {
+              const id = String(location.id)
+
+              return (
+                <tr
+                  key={location.id}
+                  className={id === selectedId ? 'is-selected' : undefined}
+                  onClick={() => onSelect(location)}
+                  onKeyDown={onRowKeyDown}
+                  role="radio"
+                  aria-checked={selectedId === id}
+                  // Only the selected row is in the tab order; arrows move selection.
+                  tabIndex={selectedId === id ? 0 : -1}
+                >
+                  <td className="services-table-select-cell">
+                    <input
+                      type="radio"
+                      name="location"
+                      className="services-table-radio"
+                      value={id}
+                      checked={selectedId === id}
+                      // Visual/a11y only; selection is handled on the row.
+                      readOnly
+                      aria-label={`${location.name}${location.address ? `, ${location.address}` : ''}`}
+                    />
+                  </td>
+                  <td className="services-table-name-cell">{location.name}</td>
+                  <td className="services-table-address-cell">{location.address || '—'}</td>
+                </tr>
+              )
+            })
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/appointment-booking/app/components/ServicesTable.tsx
+++ b/appointment-booking/app/components/ServicesTable.tsx
@@ -1,10 +1,8 @@
 import { SvgChevronDownIcon, SvgChevronUpIcon } from '@bcgov/design-system-react-components'
-import type { KeyboardEvent } from 'react'
 import type { Service } from '../api/services'
 
 type SortDirection = 'asc' | 'desc'
 
-// Presentational table: page owns fetch/filter/sort state, selection, and keyboard navigation.
 type ServicesTableProps = {
   services: Service[]
   isLoading: boolean
@@ -13,17 +11,10 @@ type ServicesTableProps = {
   onToggleSort: () => void
   selectedId: string
   onSelect: (service: Service) => void
-  onRowKeyDown: (e: KeyboardEvent<HTMLTableRowElement>) => void
 }
 
-function getRowClassName(service: Service, selectedId: string) {
-  if (!service.isOnlineBookable) {
-    return 'is-unavailable'
-  }
-  if (String(service.id) === selectedId) {
-    return 'is-selected'
-  }
-  return ''
+function getRowClassName(service: Service) {
+  return service.isOnlineBookable ? undefined : 'is-unavailable'
 }
 
 export function ServicesTable({
@@ -34,86 +25,79 @@ export function ServicesTable({
   onToggleSort,
   selectedId,
   onSelect,
-  onRowKeyDown,
 }: ServicesTableProps) {
   return (
-    <div className="services-table-wrapper">
-      <table className="services-table">
-        <thead>
-          <tr>
-            <th scope="col" className="services-table-select-heading" aria-label="Select" />
-            <th scope="col" aria-sort={sortDirection === 'asc' ? 'ascending' : 'descending'}>
-              <button
-                type="button"
-                className="services-sort-button"
-                onClick={onToggleSort}
-                aria-label={
-                  sortDirection === 'asc' ? 'Sort services Z to A' : 'Sort services A to Z'
-                }
-              >
-                <span>Services</span>
-                <span className="services-sort-icons" aria-hidden="true">
-                  <span className={sortDirection === 'asc' ? 'is-active' : undefined}>
-                    <SvgChevronUpIcon />
-                  </span>
-                  <span className={sortDirection === 'desc' ? 'is-active' : undefined}>
-                    <SvgChevronDownIcon />
-                  </span>
-                </span>
-              </button>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {isLoading ? (
+    <fieldset className="services-table-fieldset">
+      <legend className="sr-only">Select a service</legend>
+      <div className="services-table-wrapper">
+        <table className="services-table">
+          <thead>
             <tr>
-              <td colSpan={2}>Loading services...</td>
-            </tr>
-          ) : showNoResults ? (
-            <tr>
-              <td colSpan={2}>
-                No services match your search. Try different keywords or clear the search to see all
-                services.
-              </td>
-            </tr>
-          ) : (
-            services.map((service) => {
-              const id = String(service.id)
-
-              return (
-                <tr
-                  key={service.id}
-                  className={getRowClassName(service, selectedId)}
-                  onClick={() => {
-                    // Unavailable services are shown but not selectable.
-                    if (service.isOnlineBookable) onSelect(service)
-                  }}
-                  onKeyDown={onRowKeyDown}
-                  role="radio"
-                  aria-checked={selectedId === id}
-                  // Only the selected row is in the tab order; arrows move selection.
-                  tabIndex={selectedId === id ? 0 : -1}
+              <th scope="col" className="services-table-select-heading" aria-hidden="true" />
+              <th scope="col" aria-sort={sortDirection === 'asc' ? 'ascending' : 'descending'}>
+                <button
+                  type="button"
+                  className="services-sort-button"
+                  onClick={onToggleSort}
+                  aria-label={
+                    sortDirection === 'asc' ? 'Sort services Z to A' : 'Sort services A to Z'
+                  }
                 >
-                  <td className="services-table-select-cell">
-                    <input
-                      type="radio"
-                      name="service"
-                      className="services-table-radio"
-                      value={id}
-                      checked={selectedId === id}
-                      disabled={!service.isOnlineBookable}
-                      // Visual/a11y only; selection is handled on the row.
-                      readOnly
-                      aria-label={service.name}
-                    />
-                  </td>
-                  <td>{service.name}</td>
-                </tr>
-              )
-            })
-          )}
-        </tbody>
-      </table>
-    </div>
+                  <span>Services</span>
+                  <span className="services-sort-icons" aria-hidden="true">
+                    <span className={sortDirection === 'asc' ? 'is-active' : undefined}>
+                      <SvgChevronUpIcon />
+                    </span>
+                    <span className={sortDirection === 'desc' ? 'is-active' : undefined}>
+                      <SvgChevronDownIcon />
+                    </span>
+                  </span>
+                </button>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              <tr>
+                <td colSpan={2}>Loading services...</td>
+              </tr>
+            ) : showNoResults ? (
+              <tr>
+                <td colSpan={2}>
+                  No services match your search. Try different keywords or clear the search to see
+                  all services.
+                </td>
+              </tr>
+            ) : (
+              services.map((service) => {
+                const inputId = `service-${service.id}`
+
+                return (
+                  <tr key={service.id} className={getRowClassName(service)}>
+                    <td className="services-table-select-cell">
+                      <input
+                        type="radio"
+                        id={inputId}
+                        name="service"
+                        checked={selectedId === String(service.id)}
+                        disabled={!service.isOnlineBookable}
+                        onChange={() => onSelect(service)}
+                      />
+                    </td>
+                    <td>
+                      {service.isOnlineBookable ? (
+                        <label htmlFor={inputId}>{service.name}</label>
+                      ) : (
+                        service.name
+                      )}
+                    </td>
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </fieldset>
   )
 }

--- a/appointment-booking/app/routes.ts
+++ b/appointment-booking/app/routes.ts
@@ -3,5 +3,6 @@ import { type RouteConfig, index, route } from '@react-router/dev/routes'
 export default [
   index('routes/home.tsx'),
   route('services', 'routes/services.tsx'),
+  route('service-locations', 'routes/service-locations.tsx'),
   route('locations', 'routes/locations.tsx'),
 ] satisfies RouteConfig

--- a/appointment-booking/app/routes/locations.tsx
+++ b/appointment-booking/app/routes/locations.tsx
@@ -7,7 +7,7 @@ import {
   SvgChevronDownIcon,
   SvgChevronUpIcon,
 } from '@bcgov/design-system-react-components'
-import { LocationsSearch } from '../components/LocationsSearch'
+import { LocationsSearch, useNearestSort } from '../components/LocationsSearch'
 
 const PAGE_DESCRIPTION =
   'Find Service BC office locations in British Columbia. View addresses, contact details, hours of operation and book an appointment.'
@@ -1656,12 +1656,14 @@ export default function Locations() {
   const [search, setSearch] = useState('')
   const [sortColumn, setSortColumn] = useState<SortColumn>('location')
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [nearestSort, setNearestSort] = useState(false)
-  const [locationStatus, setLocationStatus] = useState<'idle' | 'loading' | 'active' | 'error'>(
-    'idle',
-  )
-  const [userLocation, setUserLocation] = useState<Coordinates | null>(null)
-  const [locationError, setLocationError] = useState<string | null>(null)
+  const {
+    nearestSort,
+    status: locationStatus,
+    userLocation,
+    error: locationError,
+    clearNearestSort,
+    toggleNearestSort,
+  } = useNearestSort()
 
   const officeDistances = useMemo(() => {
     if (!userLocation) {
@@ -1708,10 +1710,7 @@ export default function Locations() {
   }, [search, sortColumn, sortDirection, nearestSort, userLocation, officeDistances])
 
   function toggleSort(column: SortColumn) {
-    setNearestSort(false)
-    setLocationStatus('idle')
-    setUserLocation(null)
-    setLocationError(null)
+    clearNearestSort()
 
     if (sortColumn === column) {
       setSortDirection((direction) => (direction === 'asc' ? 'desc' : 'asc'))
@@ -1720,55 +1719,6 @@ export default function Locations() {
 
     setSortColumn(column)
     setSortDirection('asc')
-  }
-
-  function toggleNearestSort() {
-    if (nearestSort) {
-      setNearestSort(false)
-      setLocationStatus('idle')
-      setUserLocation(null)
-      setLocationError(null)
-      return
-    }
-
-    if (typeof navigator === 'undefined' || !navigator.geolocation) {
-      setLocationStatus('error')
-      setLocationError('Your browser does not support location services.')
-      return
-    }
-
-    setLocationStatus('loading')
-    setLocationError(null)
-
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        setUserLocation({
-          latitude: position.coords.latitude,
-          longitude: position.coords.longitude,
-        })
-        setNearestSort(true)
-        setLocationStatus('active')
-      },
-      (error) => {
-        setLocationStatus('error')
-        setNearestSort(false)
-        setUserLocation(null)
-
-        if (error.code === error.PERMISSION_DENIED) {
-          setLocationError(
-            'Location access was denied. Allow location in your browser to sort by nearest office.',
-          )
-          return
-        }
-
-        setLocationError('Unable to determine your location. Please try again.')
-      },
-      {
-        enableHighAccuracy: false,
-        timeout: 10000,
-        maximumAge: 300000,
-      },
-    )
   }
 
   return (

--- a/appointment-booking/app/routes/service-locations.tsx
+++ b/appointment-booking/app/routes/service-locations.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useMemo, useState } from 'react'
-import { InlineAlert } from '@bcgov/design-system-react-components'
+import { Callout, InlineAlert, Text } from '@bcgov/design-system-react-components'
 import { getDistance } from 'geolib'
 import { useNavigate } from 'react-router'
 import { getBookingLocations, type Location } from '../api/locations'
+import type { Service } from '../api/services'
 import { useBooking } from '../booking/booking-context'
 import { BookingBackRow } from '../components/BookingBackRow'
 import { BookingContinueRow } from '../components/BookingContinueRow'
@@ -13,6 +14,45 @@ import { LocationsTable } from '../components/LocationsTable'
 const BOOKING_STEP = 2
 const BOOKING_STEP_COUNT = 5
 const BOOKING_STEP_HEADING = 'Select a Service BC location for your appointment.'
+
+function BookingDetailCallout({
+  selectedService,
+  selectedLocation,
+}: {
+  selectedService: Service | null
+  selectedLocation: Location | null
+}) {
+  return (
+    <Callout variant="lightBlue">
+      <Text>
+        {selectedService ? (
+          <>
+            Selected service - <strong>{selectedService.name}</strong>
+            <br />
+          </>
+        ) : (
+          <>Please go back to choose a service before selecting a location.</>
+        )}
+        {selectedLocation ? (
+          <>
+            {!selectedService ? <br /> : null}
+            Appointment Location - <strong>{selectedLocation.name}</strong>
+            {selectedLocation.address ? (
+              <>
+                <br />
+                Address - <strong>{selectedLocation.address}</strong>
+              </>
+            ) : null}
+            <br />
+            Map and Specific Callouts/Announcements will appear here.
+          </>
+        ) : selectedService ? (
+          <>Select a location from the list to view details.</>
+        ) : null}
+      </Text>
+    </Callout>
+  )
+}
 
 type SortDirection = 'asc' | 'desc'
 
@@ -94,18 +134,6 @@ export default function ServiceLocationsPage() {
     return results
   }, [locations, search, sortDirection, nearestSort, userLocation])
 
-  // Arrow keys move selection among visible rows (same pattern as the services step).
-  const handleRowKeyDown = (e: React.KeyboardEvent<HTMLTableRowElement>) => {
-    if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return
-
-    const idx = visibleLocations.findIndex((location) => String(location.id) === selectedId)
-    const nextIdx = e.key === 'ArrowDown' ? idx + 1 : idx - 1
-    if (nextIdx >= 0 && nextIdx < visibleLocations.length) {
-      e.preventDefault()
-      setSelectedLocation(visibleLocations[nextIdx])
-    }
-  }
-
   const canContinue = !!selectedService && !!selectedLocation
   const showLoadError = !isLoading && loadError
   const showUnavailable = !isLoading && !loadError && locations.length === 0
@@ -121,16 +149,6 @@ export default function ServiceLocationsPage() {
         heading={BOOKING_STEP_HEADING}
       />
 
-      <p className="booking-selected-service" role="status">
-        {selectedService ? (
-          <>
-            Selected service: <strong>{selectedService.name}</strong>
-          </>
-        ) : (
-          <>Please go back to choose a service before selecting a location.</>
-        )}
-      </p>
-
       {showLoadError ? (
         <InlineAlert variant="danger" title="Unable to load locations">
           Please try again.
@@ -140,7 +158,7 @@ export default function ServiceLocationsPage() {
           Please try again.
         </InlineAlert>
       ) : (
-        <>
+        <div className="booking-locations-layout">
           {!isLoading && (
             <LocationsSearch
               value={search}
@@ -158,21 +176,33 @@ export default function ServiceLocationsPage() {
             </InlineAlert>
           ) : null}
 
-          <LocationsTable
-            locations={visibleLocations}
-            isLoading={isLoading}
-            showNoResults={showNoResults}
-            sortDirection={sortDirection}
-            onToggleSort={() => {
-              // Name sort and nearest sort are mutually exclusive.
-              clearNearestSort()
-              setSortDirection((direction) => (direction === 'asc' ? 'desc' : 'asc'))
-            }}
-            selectedId={selectedId}
-            onSelect={setSelectedLocation}
-            onRowKeyDown={handleRowKeyDown}
-          />
-        </>
+          <div className="booking-locations-body">
+            <LocationsTable
+              locations={visibleLocations}
+              isLoading={isLoading}
+              showNoResults={showNoResults}
+              sortDirection={sortDirection}
+              onToggleSort={() => {
+                // Name sort and nearest sort are mutually exclusive.
+                clearNearestSort()
+                setSortDirection((direction) => (direction === 'asc' ? 'desc' : 'asc'))
+              }}
+              selectedId={selectedId}
+              onSelect={setSelectedLocation}
+            />
+
+            <aside
+              className="booking-locations-detail"
+              aria-label="Booking selection details"
+              role="status"
+            >
+              <BookingDetailCallout
+                selectedService={selectedService}
+                selectedLocation={selectedLocation}
+              />
+            </aside>
+          </div>
+        </div>
       )}
 
       <div className="booking-nav-row">

--- a/appointment-booking/app/routes/service-locations.tsx
+++ b/appointment-booking/app/routes/service-locations.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useMemo, useState } from 'react'
+import { InlineAlert } from '@bcgov/design-system-react-components'
+import { getDistance } from 'geolib'
+import { useNavigate } from 'react-router'
+import { getBookingLocations, type Location } from '../api/locations'
+import { useBooking } from '../booking/booking-context'
+import { BookingBackRow } from '../components/BookingBackRow'
+import { BookingContinueRow } from '../components/BookingContinueRow'
+import { BookingStepProgress } from '../components/BookingStepProgress'
+import { LocationsSearch, useNearestSort, type Coordinates } from '../components/LocationsSearch'
+import { LocationsTable } from '../components/LocationsTable'
+
+const BOOKING_STEP = 2
+const BOOKING_STEP_COUNT = 5
+const BOOKING_STEP_HEADING = 'Select a Service BC location for your appointment.'
+
+type SortDirection = 'asc' | 'desc'
+
+// geolib returns meters; nearest-sort ranks by kilometres. Missing coords sort last.
+function kmFromUser(user: Coordinates, location: Location) {
+  if (location.latitude === null || location.longitude === null) {
+    return Number.POSITIVE_INFINITY
+  }
+  return getDistance(user, { latitude: location.latitude, longitude: location.longitude }) / 1000
+}
+
+export function meta() {
+  return [{ title: 'Select Location' }]
+}
+
+export default function ServiceLocationsPage() {
+  const navigate = useNavigate()
+  const { selectedService, selectedLocation, setSelectedLocation } = useBooking()
+  const selectedId = selectedLocation ? String(selectedLocation.id) : ''
+
+  const [locations, setLocations] = useState<Location[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState(false)
+  const [search, setSearch] = useState('')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
+  const {
+    nearestSort,
+    status: locationStatus,
+    userLocation,
+    error: locationError,
+    clearNearestSort,
+    toggleNearestSort,
+  } = useNearestSort()
+
+  // Ignore late responses if the user leaves the page mid-fetch (SSR/client remounts).
+  useEffect(() => {
+    let cancelled = false
+    getBookingLocations()
+      .then((loaded) => {
+        if (!cancelled) {
+          setLocations(loaded)
+          setLoadError(false)
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLoadError(true)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setIsLoading(false)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const visibleLocations = useMemo(() => {
+    const tokens = search.trim().toLowerCase().split(/\s+/).filter(Boolean)
+    // Copy before sort — Array.sort mutates in place.
+    const results = tokens.length
+      ? locations.filter((location) => {
+          const haystack = `${location.name} ${location.address}`.toLowerCase()
+          return tokens.every((token) => haystack.includes(token))
+        })
+      : [...locations]
+
+    if (nearestSort && userLocation) {
+      results.sort((a, b) => kmFromUser(userLocation, a) - kmFromUser(userLocation, b))
+      return results
+    }
+
+    results.sort((a, b) => {
+      const comparison = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+      return sortDirection === 'asc' ? comparison : -comparison
+    })
+    return results
+  }, [locations, search, sortDirection, nearestSort, userLocation])
+
+  // Arrow keys move selection among visible rows (same pattern as the services step).
+  const handleRowKeyDown = (e: React.KeyboardEvent<HTMLTableRowElement>) => {
+    if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return
+
+    const idx = visibleLocations.findIndex((location) => String(location.id) === selectedId)
+    const nextIdx = e.key === 'ArrowDown' ? idx + 1 : idx - 1
+    if (nextIdx >= 0 && nextIdx < visibleLocations.length) {
+      e.preventDefault()
+      setSelectedLocation(visibleLocations[nextIdx])
+    }
+  }
+
+  const canContinue = !!selectedService && !!selectedLocation
+  const showLoadError = !isLoading && loadError
+  const showUnavailable = !isLoading && !loadError && locations.length === 0
+  const showNoResults = !isLoading && locations.length > 0 && visibleLocations.length === 0
+
+  return (
+    <>
+      <h1 className="sr-only">Select Location</h1>
+
+      <BookingStepProgress
+        step={BOOKING_STEP}
+        stepCount={BOOKING_STEP_COUNT}
+        heading={BOOKING_STEP_HEADING}
+      />
+
+      <p className="booking-selected-service" role="status">
+        {selectedService ? (
+          <>
+            Selected service: <strong>{selectedService.name}</strong>
+          </>
+        ) : (
+          <>Please go back to choose a service before selecting a location.</>
+        )}
+      </p>
+
+      {showLoadError ? (
+        <InlineAlert variant="danger" title="Unable to load locations">
+          Please try again.
+        </InlineAlert>
+      ) : showUnavailable ? (
+        <InlineAlert variant="info" title="No locations available">
+          Please try again.
+        </InlineAlert>
+      ) : (
+        <>
+          {!isLoading && (
+            <LocationsSearch
+              value={search}
+              onChange={setSearch}
+              onClear={() => setSearch('')}
+              nearestSort={nearestSort}
+              nearestStatus={locationStatus}
+              onNearestSortPress={toggleNearestSort}
+            />
+          )}
+
+          {locationError ? (
+            <InlineAlert variant="danger" title="Location unavailable">
+              {locationError}
+            </InlineAlert>
+          ) : null}
+
+          <LocationsTable
+            locations={visibleLocations}
+            isLoading={isLoading}
+            showNoResults={showNoResults}
+            sortDirection={sortDirection}
+            onToggleSort={() => {
+              // Name sort and nearest sort are mutually exclusive.
+              clearNearestSort()
+              setSortDirection((direction) => (direction === 'asc' ? 'desc' : 'asc'))
+            }}
+            selectedId={selectedId}
+            onSelect={setSelectedLocation}
+            onRowKeyDown={handleRowKeyDown}
+          />
+        </>
+      )}
+
+      <div className="booking-nav-row">
+        <BookingBackRow onBack={() => navigate('/services')} />
+        <BookingContinueRow isDisabled={!canContinue} />
+      </div>
+    </>
+  )
+}

--- a/appointment-booking/app/routes/services.tsx
+++ b/appointment-booking/app/routes/services.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { InlineAlert } from '@bcgov/design-system-react-components'
+import { useNavigate } from 'react-router'
 import { getPublicServices, type Service } from '../api/services'
 import { useBooking } from '../booking/booking-context'
 import { BookingContinueRow } from '../components/BookingContinueRow'
@@ -19,6 +20,7 @@ export function meta() {
 }
 
 export default function ServicesPage() {
+  const navigate = useNavigate()
   // Selection lives in booking context so later steps can reuse it.
   const { selectedService, setSelectedService } = useBooking()
   const selectedId = selectedService ? String(selectedService.id) : ''
@@ -138,7 +140,10 @@ export default function ServicesPage() {
         </>
       )}
 
-      <BookingContinueRow isDisabled={!canContinue} />
+      <BookingContinueRow
+        isDisabled={!canContinue}
+        onContinue={() => navigate('/service-locations')}
+      />
     </>
   )
 }

--- a/appointment-booking/app/routes/services.tsx
+++ b/appointment-booking/app/routes/services.tsx
@@ -74,20 +74,6 @@ export default function ServicesPage() {
     return results
   }, [services, search, sortDirection])
 
-  // Navigate between bookable services using arrow keys
-  const handleRowKeyDown = (e: React.KeyboardEvent<HTMLTableRowElement>) => {
-    if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return
-
-    const bookable = visibleServices.filter((s) => s.isOnlineBookable)
-    const idx = bookable.findIndex((s) => String(s.id) === selectedId)
-    const nextIdx = e.key === 'ArrowDown' ? idx + 1 : idx - 1
-
-    if (nextIdx >= 0 && nextIdx < bookable.length) {
-      e.preventDefault()
-      setSelectedService(bookable[nextIdx])
-    }
-  }
-
   // Page owns Continue enablement; only a bookable selection unlocks the next step.
   const canContinue = !!selectedService?.isOnlineBookable
   const hasUnavailableServices = services.some((service) => !service.isOnlineBookable)
@@ -129,7 +115,6 @@ export default function ServicesPage() {
             }
             selectedId={selectedId}
             onSelect={setSelectedService}
-            onRowKeyDown={handleRowKeyDown}
           />
 
           {!isLoading && hasUnavailableServices && (


### PR DESCRIPTION
### Summary

1. Added booking step 2 (/service-locations) to pick a Service BC office after a service is selected
2. It Loads offices via a locations API client; supports search, name sort, and nearest-location sort
3. Shared nearest-sort logic (useNearestSort) between the location directory and booking flows; 
4. It persists the selected location in booking context to use in the next steps in the same way service persists.

### Test plan

1.  From Services, continue to Service Locations and confirm offices load
2.  Search / clear, sort by name, and nearest pin (allow / deny geolocation)
3.  Select a location → Continue enabled; Back returns to Services with selection retained

You can also test in Openshift - https://dev-appointments.apps.silver.devops.gov.bc.ca/