### PR TITLE
Add office_appointment_message from the offices API into location page

### DIFF
--- a/appointment-booking/app/api/locations.ts
+++ b/appointment-booking/app/api/locations.ts
@@ -7,6 +7,7 @@ export type Location = {
   address: string
   latitude: number | null
   longitude: number | null
+  appointmentMessage: string
 }
 
 // API response row from GET /api/v1/offices/.
@@ -19,6 +20,7 @@ type ApiOffice = {
   appointments_enabled_ind: number
   online_status: string | null
   deleted: string | null
+  office_appointment_message: string | null
 }
 
 type ApiOfficesResponse = {
@@ -56,6 +58,7 @@ export async function getBookingLocations(): Promise<Location[]> {
       address: row.civic_address?.trim() || '',
       latitude: row.latitude,
       longitude: row.longitude,
+      appointmentMessage: row.office_appointment_message?.trim() || '',
     })
   }
 

--- a/appointment-booking/app/app.css
+++ b/appointment-booking/app/app.css
@@ -374,6 +374,15 @@ p {
   order: 1;
 }
 
+/* Full-width stack so the nested location notice sits below the selection text. */
+.booking-detail-callout-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--layout-padding-medium);
+  min-width: 0;
+  width: 100%;
+}
+
 .booking-locations-body > .services-table-fieldset {
   min-width: 0;
   order: 2;

--- a/appointment-booking/app/routes/service-locations.tsx
+++ b/appointment-booking/app/routes/service-locations.tsx
@@ -15,6 +15,7 @@ const BOOKING_STEP = 2
 const BOOKING_STEP_COUNT = 5
 const BOOKING_STEP_HEADING = 'Select a Service BC location for your appointment.'
 
+// Selection summary; nested InlineAlert shows the office online appointment message when set.
 function BookingDetailCallout({
   selectedService,
   selectedLocation,
@@ -24,32 +25,37 @@ function BookingDetailCallout({
 }) {
   return (
     <Callout variant="lightBlue">
-      <Text>
-        {selectedService ? (
-          <>
-            Selected service - <strong>{selectedService.name}</strong>
-            <br />
-          </>
-        ) : (
-          <>Please go back to choose a service before selecting a location.</>
-        )}
-        {selectedLocation ? (
-          <>
-            {!selectedService ? <br /> : null}
-            Appointment Location - <strong>{selectedLocation.name}</strong>
-            {selectedLocation.address ? (
-              <>
-                <br />
-                Address - <strong>{selectedLocation.address}</strong>
-              </>
-            ) : null}
-            <br />
-            Map and Specific Callouts/Announcements will appear here.
-          </>
-        ) : selectedService ? (
-          <>Select a location from the list to view details.</>
+      <div className="booking-detail-callout-content">
+        <Text>
+          {selectedService ? (
+            <>
+              Selected service - <strong>{selectedService.name}</strong>
+              <br />
+            </>
+          ) : (
+            <>Please go back to choose a service before selecting a location.</>
+          )}
+          {selectedLocation ? (
+            <>
+              {!selectedService ? <br /> : null}
+              Appointment Location - <strong>{selectedLocation.name}</strong>
+              {selectedLocation.address ? (
+                <>
+                  <br />
+                  Address - <strong>{selectedLocation.address}</strong>
+                </>
+              ) : null}
+            </>
+          ) : selectedService ? (
+            <>Select a location from the list to view details.</>
+          ) : null}
+        </Text>
+        {selectedLocation?.appointmentMessage ? (
+          <InlineAlert variant="info" title="Location notice">
+            {selectedLocation.appointmentMessage}
+          </InlineAlert>
         ) : null}
-      </Text>
+      </div>
     </Callout>
   )
 }


### PR DESCRIPTION

Summary

- Map office_appointment_message from the offices API into each booking location as appointmentMessage.
- When a location is selected on the service-locations step, show that message as an info InlineAlert (“Location notice”) inside the booking detail callout.