### PR TITLE
Add API endpoint for offices by service ID

### DIFF
--- a/api/app/resources/theq/offices.py
+++ b/api/app/resources/theq/offices.py
@@ -12,12 +12,72 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.'''
 
+import datetime
 import logging
-from flask import g
+
+from flask import request
 from flask_restx import Resource
 from qsystem import api, db
 from sqlalchemy import exc
-from app.models.theq import CSR, Office
+from app.models.theq import Office, Service
+from app.schemas.theq import OfficeSchema
+from app.services import AvailabilityService
+from app.utilities.timezone_utils import get_timezone
+
+
+@api.route("/offices", methods=["GET"])
+class OfficesByService(Resource):
+
+    @staticmethod
+    def _get_next_appointment_date(office, service):
+        timezone = get_timezone(office.timezone.timezone_name)
+        today = datetime.datetime.now().astimezone(timezone)
+        days = [
+            today + datetime.timedelta(days=day)
+            for day in range(office.appointments_days_limit or 0)
+        ]
+
+        if not days:
+            return None
+
+        available_slots = AvailabilityService.get_available_slots(
+            office=office, days=days, service=service
+        )
+        for day in days:
+            if available_slots.get(day.strftime('%m/%d/%Y')):
+                return day.date().isoformat()
+
+        return None
+
+    def get(self):
+        try:
+            service_id = int(request.args.get('service_id'))
+        except (TypeError, ValueError):
+            return {'message': 'service_id must be an integer.'}, 400
+
+        try:
+            service = db.session.get(Service, service_id)
+            if service is None:
+                return {'offices': [],
+                        'errors': {}}
+
+            offices = Office.query.join(Office.services).filter(
+                Service.service_id == service_id,
+                Office.deleted.is_(None)
+            ).order_by(Office.office_name).all()
+            result = OfficeSchema(many=True).dump(offices)
+
+            for office, serialized_office in zip(offices, result):
+                serialized_office['next_appointment_date'] = self._get_next_appointment_date(
+                    office, service
+                )
+
+            return {'offices': result,
+                    'errors': {}}
+
+        except exc.SQLAlchemyError as exception:
+            logging.exception(exception)
+            return {'message': 'API is down'}, 500
 
 
 @api.route("/offices/", methods=["GET"])

--- a/api/app/tests/auth/test_open_routes.py
+++ b/api/app/tests/auth/test_open_routes.py
@@ -85,6 +85,94 @@ def test_bare_client_can_access_slots_without_authentication(bare_client, seeded
     assert json_of(response)
 
 
+def test_bare_client_can_find_active_offices_and_next_dates_by_service(
+    bare_client, seeded_data, app, monkeypatch
+):
+    """Assert that public service-scoped office discovery includes the next available date."""
+    from datetime import datetime
+
+    from app.models.theq import Office, Service
+    from app.resources.theq.offices import AvailabilityService
+    from app.utilities.yesno import YesNo
+    from qsystem import db
+
+    service_id = seeded_data["service_ids"]["msp"]
+    test_office_id = seeded_data["office_ids"]["test_office"]
+    victoria_office_id = seeded_data["office_ids"]["victoria"]
+
+    with app.app_context():
+        service = db.session.get(Service, service_id)
+        service.timeslot_duration = 45
+        service.is_dlkt = YesNo.YES
+        deleted_office = db.session.get(
+            Office, seeded_data["office_ids"]["limited_office"]
+        )
+        deleted_office.services.append(service)
+        deleted_office.deleted = datetime.now()
+        db.session.commit()
+
+    calls = []
+    expected_next_date = None
+
+    def available_slots(office, days, service):
+        nonlocal expected_next_date
+        calls.append(
+            (
+                office.office_id,
+                service.service_id,
+                service.timeslot_duration,
+                service.is_dlkt,
+            )
+        )
+        slots = {day.strftime("%m/%d/%Y"): [] for day in days}
+        if office.office_id == test_office_id:
+            expected_next_date = days[1].date().isoformat()
+            slots[days[1].strftime("%m/%d/%Y")] = [{"start_time": "09:00"}]
+        return slots
+
+    monkeypatch.setattr(
+        AvailabilityService, "get_available_slots", available_slots
+    )
+
+    response = bare_client.get(f"/offices?service_id={service_id}")
+    body = json_of(response)
+
+    assert_json_response(response, 200)
+    assert body["errors"] == {}
+    assert [office["office_name"] for office in body["offices"]] == [
+        "Test Office",
+        "Victoria",
+    ]
+    offices_by_id = {office["office_id"]: office for office in body["offices"]}
+    assert offices_by_id[test_office_id]["next_appointment_date"] == expected_next_date
+    assert offices_by_id[victoria_office_id]["next_appointment_date"] is None
+    assert calls == [
+        (test_office_id, service_id, 45, YesNo.YES),
+        (victoria_office_id, service_id, 45, YesNo.YES),
+    ]
+
+    existing_response = bare_client.get("/offices/")
+    assert_json_response(existing_response, 200)
+    assert all(
+        "next_appointment_date" not in office
+        for office in json_of(existing_response)["offices"]
+    )
+
+
+def test_service_scoped_offices_validates_service_id(bare_client):
+    """Assert that malformed service filters fail and unknown services return no offices."""
+    for path in ("/offices", "/offices?service_id=not-an-integer"):
+        response = bare_client.get(path)
+
+        assert_json_response(response, 400)
+        assert json_of(response)["message"] == "service_id must be an integer."
+
+    response = bare_client.get("/offices?service_id=2147483647")
+
+    assert_json_response(response, 200)
+    assert json_of(response) == {"offices": [], "errors": {}}
+
+
 def test_bare_client_can_access_walkin_lookup_without_authentication(
     bare_client, internal_ga_client, seeded_data, app
 ):


### PR DESCRIPTION
Implemented the public `GET /api/v1/offices?service_id={id}` endpoint from https://citz-sbc.atlassian.net/browse/DEV-74.

### Key behavior:

- Filters active offices through `office_service`.
- Adds `next_appointment_date` as YYYY-MM-DD or `null` (if no next appointment date exists within the max availability window.
- Uses the selected service’s duration and DLKT settings via `AvailabilityService`.
- Handles malformed and unknown service IDs as planned.
- Leaves the existing `/api/v1/offices/` response unchanged.