### PR TITLE
Add date/time selection step for appointment booking.

### DIFF
--- a/appointment-booking/app/api/timeslots.ts
+++ b/appointment-booking/app/api/timeslots.ts
@@ -1,0 +1,77 @@
+import { getApiBaseUrl } from '../runtime-config'
+
+// Start and end time shown in the booking UI.
+export type TimeSlot = {
+  startTime: string
+  endTime: string
+}
+
+// Available times grouped by date (YYYY-MM-DD).
+export type AvailableTimeSlots = Record<string, TimeSlot[]>
+
+// One slot as returned by the office slots API.
+type ApiTimeSlot = {
+  start_time: string
+  end_time: string
+  no_of_slots: number
+}
+
+// The API groups slots by MM/DD/YYYY dates.
+type ApiAvailableTimeSlots = Record<string, ApiTimeSlot[]>
+
+// Convert MM/DD/YYYY to YYYY-MM-DD. Skip bad dates instead of failing the whole load.
+function toIsoDate(date: string): string | null {
+  const [month, day, year] = date.split('/')
+  if (!month || !day || !year) {
+    return null
+  }
+  return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
+}
+
+// Load bookable times for the selected office and service.
+// Throws when the request fails so the page can show an error, not "no times available".
+export async function getAvailableTimeSlots(
+  officeId: number,
+  serviceId: number,
+): Promise<AvailableTimeSlots> {
+  const url = `${await getApiBaseUrl()}/offices/${officeId}/slots/?service_id=${serviceId}`
+
+  let body: ApiAvailableTimeSlots
+  try {
+    const response = await fetch(url)
+    if (!response.ok) {
+      throw new Error('Failed to load time slots')
+    }
+    body = (await response.json()) as ApiAvailableTimeSlots
+  } catch {
+    throw new Error('Failed to load time slots')
+  }
+
+  if (!body || typeof body !== 'object') {
+    throw new Error('Failed to load time slots')
+  }
+
+  const availableTimeSlots: AvailableTimeSlots = {}
+
+  for (const [date, slots] of Object.entries(body)) {
+    const isoDate = toIsoDate(date)
+    if (!isoDate) {
+      continue
+    }
+
+    // Skip slots with no openings left, in case the API includes them.
+    const availableSlots = slots
+      .filter((slot) => slot.no_of_slots > 0)
+      .map((slot) => ({
+        startTime: slot.start_time,
+        endTime: slot.end_time,
+      }))
+
+    // Leave empty days out so the calendar can mark them unavailable.
+    if (availableSlots.length > 0) {
+      availableTimeSlots[isoDate] = availableSlots
+    }
+  }
+
+  return availableTimeSlots
+}

--- a/appointment-booking/app/app.css
+++ b/appointment-booking/app/app.css
@@ -237,6 +237,10 @@ p {
   overflow-x: auto;
   width: 100%;
   max-width: 100%;
+}
+
+.services-table-wrapper,
+.datetime-selection-panel {
   box-sizing: border-box;
   background: var(--surface-color-background-white);
   border: var(--layout-border-width-small) solid var(--surface-color-border-default);
@@ -564,6 +568,158 @@ p {
 
 .login-alert {
   margin-bottom: var(--layout-margin-large);
+}
+
+.datetime-status {
+  margin-top: var(--layout-margin-large);
+}
+
+/* Same gold top bar used on the services and locations tables. */
+.datetime-selection-panel {
+  margin-top: var(--layout-margin-large);
+  padding: var(--layout-padding-xlarge);
+}
+
+.datetime-selection {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--layout-padding-xlarge);
+}
+
+.datetime-selection h2 {
+  margin-top: 0;
+  font: var(--typography-bold-h3);
+}
+
+.datetime-selected-day {
+  margin: var(--layout-margin-medium) 0 0;
+  padding: var(--layout-padding-small) var(--layout-padding-medium);
+  width: fit-content;
+  max-width: 100%;
+  box-sizing: border-box;
+  border-radius: var(--layout-border-radius-medium);
+  background: var(--theme-blue-10);
+  font: var(--typography-regular-small-body);
+  color: var(--typography-color-secondary);
+  text-align: center;
+}
+
+.datetime-time-panel {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.datetime-calendar-legend {
+  margin: var(--layout-margin-small) 0 0;
+  padding: 0 0 0 1.25rem;
+  width: fit-content;
+  max-width: 100%;
+  box-sizing: border-box;
+  list-style-position: outside;
+  text-align: left;
+  font: var(--typography-regular-small-body);
+  color: var(--typography-color-secondary);
+}
+
+.datetime-calendar-legend-unavailable {
+  color: var(--typography-color-danger);
+  text-decoration: line-through;
+}
+
+.datetime-calendar-legend-disabled {
+  color: var(--typography-color-disabled);
+}
+
+.datetime-time-slots {
+  width: 100%;
+  max-width: 28rem;
+}
+
+.datetime-time-slots .bcds-react-aria-RadioGroup--options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: stretch;
+  width: 100%;
+  gap: var(--layout-padding-medium);
+}
+
+.datetime-time-slots .bcds-react-aria-Radio {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 2.75rem;
+  padding: var(--layout-padding-medium);
+  border: var(--layout-border-width-small) solid var(--surface-color-border-default);
+  border-radius: var(--layout-border-radius-medium);
+  background: var(--surface-color-background-white);
+  cursor: pointer;
+}
+
+.datetime-time-slots .bcds-react-aria-Radio[data-selected] {
+  border-color: var(--surface-color-border-active);
+  background: var(--theme-blue-10);
+  box-shadow: inset var(--layout-border-width-medium) 0 0 0 var(--theme-blue-80);
+}
+
+/* Make the calendar wider on desktop so it fills its column. */
+@media (min-width: 48rem) {
+  .datetime-selection .bcds-react-aria-Calendar {
+    display: flex;
+    width: 100%;
+    max-width: 26rem;
+  }
+
+  .datetime-selection .bcds-react-aria-Calendar--GridContainer,
+  .datetime-selection .bcds-react-aria-Calendar--Header,
+  .datetime-selection .bcds-react-aria-Calendar--Grid {
+    width: 100%;
+  }
+
+  .datetime-selection .bcds-react-aria-Calendar--GridContainer {
+    flex: 1 1 auto;
+  }
+
+  .datetime-selection .bcds-react-aria-Calendar--Cell {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
+}
+
+@media (max-width: 48rem) {
+  .datetime-selection {
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .datetime-selection section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+  }
+
+  .datetime-time-panel {
+    align-items: center;
+  }
+
+  .datetime-selected-day {
+    order: -1;
+    margin: 0 0 var(--layout-margin-medium);
+  }
+
+  .datetime-calendar-legend {
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .datetime-time-slots .bcds-react-aria-RadioGroup--options {
+    grid-template-columns: 1fr;
+  }
 }
 
 .header-account {

--- a/appointment-booking/app/app.css
+++ b/appointment-booking/app/app.css
@@ -592,7 +592,7 @@ p {
 }
 
 .datetime-selected-day {
-  margin: var(--layout-margin-medium) 0 0;
+  margin: 0 0 var(--layout-margin-medium);
   padding: var(--layout-padding-small) var(--layout-padding-medium);
   width: fit-content;
   max-width: 100%;
@@ -637,32 +637,13 @@ p {
   max-width: 28rem;
 }
 
-.datetime-time-slots .bcds-react-aria-RadioGroup--options {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  align-items: stretch;
+/* Stretch the select so the full "9:00 a.m. – 9:15 a.m." label fits on one line. */
+.datetime-time-slots .bcds-react-aria-Select {
   width: 100%;
-  gap: var(--layout-padding-medium);
 }
 
-.datetime-time-slots .bcds-react-aria-Radio {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-sizing: border-box;
+.datetime-time-slots .bcds-react-aria-Select--Button {
   width: 100%;
-  min-height: 2.75rem;
-  padding: var(--layout-padding-medium);
-  border: var(--layout-border-width-small) solid var(--surface-color-border-default);
-  border-radius: var(--layout-border-radius-medium);
-  background: var(--surface-color-background-white);
-  cursor: pointer;
-}
-
-.datetime-time-slots .bcds-react-aria-Radio[data-selected] {
-  border-color: var(--surface-color-border-active);
-  background: var(--theme-blue-10);
-  box-shadow: inset var(--layout-border-width-medium) 0 0 0 var(--theme-blue-80);
 }
 
 /* Make the calendar wider on desktop so it fills its column. */
@@ -707,18 +688,9 @@ p {
     align-items: center;
   }
 
-  .datetime-selected-day {
-    order: -1;
-    margin: 0 0 var(--layout-margin-medium);
-  }
-
   .datetime-calendar-legend {
     margin-left: auto;
     margin-right: auto;
-  }
-
-  .datetime-time-slots .bcds-react-aria-RadioGroup--options {
-    grid-template-columns: 1fr;
   }
 }
 

--- a/appointment-booking/app/auth/session-keys.ts
+++ b/appointment-booking/app/auth/session-keys.ts
@@ -12,6 +12,7 @@ export const SessionKeys = {
   // Booking selections survive the IdP redirect round-trip.
   BookingSelectedService: 'BOOKING_SELECTED_SERVICE',
   BookingSelectedLocation: 'BOOKING_SELECTED_LOCATION',
+  BookingSelectedSlot: 'BOOKING_SELECTED_SLOT',
 } as const
 
 // Cleared on logout and when discarding a bad/disallowed auth session.
@@ -28,6 +29,7 @@ export const AUTH_SESSION_KEYS = [
 export const BOOKING_SESSION_KEYS = [
   SessionKeys.BookingSelectedService,
   SessionKeys.BookingSelectedLocation,
+  SessionKeys.BookingSelectedSlot,
 ] as const
 
 export const IdpHint = {

--- a/appointment-booking/app/booking/booking-context.tsx
+++ b/appointment-booking/app/booking/booking-context.tsx
@@ -1,44 +1,54 @@
-// Shared service + location selection across booking steps.
-// Also saved to sessionStorage so selections survive the BCSC redirect.
+// Shared service, location, and appointment time across booking steps.
+// Also saved in the browser so choices survive the sign-in redirect.
 import { useContext, useEffect, useState, type ReactNode } from 'react'
 
 import type { Location } from '../api/locations'
 import type { Service } from '../api/services'
 import { addJsonToSession, getJsonFromSession, removeFromSession } from '../auth/session'
 import { SessionKeys } from '../auth/session-keys'
-import { BookingContext } from './booking-store'
+import { BookingContext, type BookingSlot } from './booking-store'
+
+function persistJson(key: string, value: unknown) {
+  if (value) {
+    addJsonToSession(key, value)
+  } else {
+    removeFromSession(key)
+  }
+}
 
 export function BookingProvider({ children }: { children: ReactNode }) {
   const [isReady, setIsReady] = useState(false)
   const [selectedService, setSelectedServiceState] = useState<Service | null>(null)
   const [selectedLocation, setSelectedLocationState] = useState<Location | null>(null)
+  const [selectedSlot, setSelectedSlotState] = useState<BookingSlot | null>(null)
 
   useEffect(() => {
-    // sessionStorage is browser-only, so restore it after the initial render.
+    // Restore saved choices after the page first loads in the browser.
     const id = window.setTimeout(() => {
       setSelectedServiceState(getJsonFromSession<Service>(SessionKeys.BookingSelectedService))
       setSelectedLocationState(getJsonFromSession<Location>(SessionKeys.BookingSelectedLocation))
+      setSelectedSlotState(getJsonFromSession<BookingSlot>(SessionKeys.BookingSelectedSlot))
       setIsReady(true)
     }, 0)
     return () => window.clearTimeout(id)
   }, [])
 
+  // Changing service or location clears any time already chosen.
   function setSelectedService(service: Service | null) {
     setSelectedServiceState(service)
-    if (service) {
-      addJsonToSession(SessionKeys.BookingSelectedService, service)
-    } else {
-      removeFromSession(SessionKeys.BookingSelectedService)
-    }
+    setSelectedSlot(null)
+    persistJson(SessionKeys.BookingSelectedService, service)
   }
 
   function setSelectedLocation(location: Location | null) {
     setSelectedLocationState(location)
-    if (location) {
-      addJsonToSession(SessionKeys.BookingSelectedLocation, location)
-    } else {
-      removeFromSession(SessionKeys.BookingSelectedLocation)
-    }
+    setSelectedSlot(null)
+    persistJson(SessionKeys.BookingSelectedLocation, location)
+  }
+
+  function setSelectedSlot(slot: BookingSlot | null) {
+    setSelectedSlotState(slot)
+    persistJson(SessionKeys.BookingSelectedSlot, slot)
   }
 
   return (
@@ -49,6 +59,8 @@ export function BookingProvider({ children }: { children: ReactNode }) {
         setSelectedService,
         selectedLocation,
         setSelectedLocation,
+        selectedSlot,
+        setSelectedSlot,
       }}
     >
       {children}

--- a/appointment-booking/app/booking/booking-store.ts
+++ b/appointment-booking/app/booking/booking-store.ts
@@ -3,12 +3,21 @@ import { createContext } from 'react'
 import type { Location } from '../api/locations'
 import type { Service } from '../api/services'
 
+// The chosen appointment date and time. Date is YYYY-MM-DD; times are HH:MM.
+export type BookingSlot = {
+  date: string
+  startTime: string
+  endTime: string
+}
+
 export type BookingContextValue = {
   isReady: boolean
   selectedService: Service | null
   setSelectedService: (service: Service | null) => void
   selectedLocation: Location | null
   setSelectedLocation: (location: Location | null) => void
+  selectedSlot: BookingSlot | null
+  setSelectedSlot: (slot: BookingSlot | null) => void
 }
 
 // Isolated from component exports so Vite/Fast Refresh cannot duplicate this context.

--- a/appointment-booking/app/routes.ts
+++ b/appointment-booking/app/routes.ts
@@ -6,5 +6,6 @@ export default [
   route('service-locations', 'routes/service-locations.tsx'),
   route('signin/:idpHint', 'routes/signin.$idpHint.tsx'),
   route('login', 'routes/login.tsx'),
+  route('datetime', 'routes/datetime.tsx'),
   route('locations', 'routes/locations.tsx'),
 ] satisfies RouteConfig

--- a/appointment-booking/app/routes/datetime.tsx
+++ b/appointment-booking/app/routes/datetime.tsx
@@ -1,0 +1,291 @@
+import { useEffect, useState } from 'react'
+import {
+  Button,
+  Calendar,
+  Callout,
+  InlineAlert,
+  Radio,
+  RadioGroup,
+  Text,
+} from '@bcgov/design-system-react-components'
+import { parseDate } from '@internationalized/date'
+import { useNavigate } from 'react-router'
+
+import { getAvailableTimeSlots, type AvailableTimeSlots } from '~/api/timeslots'
+import { useAuth } from '~/auth/auth-context'
+import { useBooking } from '~/booking/booking-context'
+import { BookingBackRow } from '~/components/BookingBackRow'
+import { BookingStepProgress } from '~/components/BookingStepProgress'
+
+const BOOKING_STEP = 4
+const BOOKING_STEP_COUNT = 5
+const BOOKING_STEP_HEADING = 'Select a date and time for your appointment.'
+
+function formatDate(date: string) {
+  const [year, month, day] = date.split('-').map(Number)
+  return new Intl.DateTimeFormat('en-CA', {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(year, month - 1, day))
+}
+
+function formatTime(time: string) {
+  const [hour, minute] = time.split(':').map(Number)
+  return new Intl.DateTimeFormat('en-CA', {
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(2000, 0, 1, hour, minute))
+}
+
+function formatTimeRange(startTime: string, endTime: string) {
+  return `${formatTime(startTime)} – ${formatTime(endTime)}`
+}
+
+function slotValue(startTime: string, endTime: string) {
+  return `${startTime}|${endTime}`
+}
+
+export function meta() {
+  return [{ title: 'Select Date and Time' }]
+}
+
+export default function DateTimePage() {
+  const navigate = useNavigate()
+  const { isReady: isAuthReady, isAuthenticated } = useAuth()
+  const {
+    isReady: isBookingReady,
+    selectedService,
+    selectedLocation,
+    selectedSlot,
+    setSelectedSlot,
+  } = useBooking()
+  const [timeSlots, setTimeSlots] = useState<AvailableTimeSlots>({})
+  const [selectedDay, setSelectedDay] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [loadError, setLoadError] = useState(false)
+
+  useEffect(() => {
+    if (
+      !isAuthReady ||
+      !isBookingReady ||
+      !isAuthenticated ||
+      !selectedService ||
+      !selectedLocation
+    ) {
+      return
+    }
+
+    let cancelled = false
+
+    // Wait a moment before loading so we can clear any old error and show loading again.
+    const startId = window.setTimeout(() => {
+      if (cancelled) {
+        return
+      }
+
+      setIsLoading(true)
+      setLoadError(false)
+
+      getAvailableTimeSlots(selectedLocation.id, selectedService.id)
+        .then((loaded) => {
+          if (!cancelled) setTimeSlots(loaded)
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setTimeSlots({})
+            setLoadError(true)
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setIsLoading(false)
+        })
+    }, 0)
+
+    return () => {
+      cancelled = true
+      window.clearTimeout(startId)
+    }
+  }, [isAuthReady, isBookingReady, isAuthenticated, selectedLocation, selectedService])
+
+  const availableDates = Object.keys(timeSlots).sort()
+  // Prefer the day the user clicked; if none, use the day from a previously saved time.
+  const activeDay =
+    selectedDay ?? (selectedSlot && timeSlots[selectedSlot.date] ? selectedSlot.date : null)
+  const activeDaySlots = activeDay ? (timeSlots[activeDay] ?? []) : []
+  const selectedSlotValue =
+    selectedSlot?.date === activeDay ? slotValue(selectedSlot.startTime, selectedSlot.endTime) : ''
+
+  const stepProgress = (
+    <BookingStepProgress
+      step={BOOKING_STEP}
+      stepCount={BOOKING_STEP_COUNT}
+      heading={BOOKING_STEP_HEADING}
+    />
+  )
+
+  if (!isAuthReady || !isBookingReady) {
+    return (
+      <div className="sign-in-panel" role="status" aria-live="polite">
+        <Text>Loading booking…</Text>
+      </div>
+    )
+  }
+
+  if (!selectedService || !selectedLocation) {
+    return (
+      <>
+        {stepProgress}
+        <InlineAlert variant="warning" title="Start your booking">
+          Please go back to the services page and start by selecting a service, then a location.
+        </InlineAlert>
+        <div className="booking-nav-row">
+          <Button type="button" onPress={() => navigate('/services')}>
+            Go to services
+          </Button>
+        </div>
+      </>
+    )
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <>
+        {stepProgress}
+        <InlineAlert variant="warning" title="Sign in to continue">
+          Please sign in before selecting a date and time for your appointment.
+        </InlineAlert>
+        <div className="booking-nav-row">
+          <Button type="button" onPress={() => navigate('/login')}>
+            Go to login
+          </Button>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <h1 className="sr-only">Select Date and Time</h1>
+      {stepProgress}
+
+      <Callout variant="lightBlue">
+        <div className="booking-detail-callout-content">
+          <Text>
+            Selected Service - <strong>{selectedService.name}</strong>
+            <br />
+            Appointment Location - <strong>{selectedLocation.name}</strong>
+            {selectedLocation.address ? (
+              <>
+                <br />
+                Address - <strong>{selectedLocation.address}</strong>
+              </>
+            ) : null}
+            {selectedSlot ? (
+              <>
+                <br />
+                Appointment Date - <strong>{formatDate(selectedSlot.date)}</strong>
+                <br />
+                Appointment Time -{' '}
+                <strong>{formatTimeRange(selectedSlot.startTime, selectedSlot.endTime)}</strong>
+              </>
+            ) : null}
+          </Text>
+          {selectedLocation.appointmentMessage ? (
+            <InlineAlert variant="info" title="Location notice">
+              {selectedLocation.appointmentMessage}
+            </InlineAlert>
+          ) : null}
+        </div>
+      </Callout>
+
+      {isLoading ? (
+        <div className="datetime-status" role="status" aria-live="polite">
+          <Text>Loading available dates and times…</Text>
+        </div>
+      ) : loadError ? (
+        <div className="datetime-status">
+          <InlineAlert variant="danger" title="Unable to load available times">
+            Please try again.
+          </InlineAlert>
+        </div>
+      ) : availableDates.length === 0 ? (
+        <div className="datetime-status">
+          <InlineAlert variant="info" title="No appointments available">
+            There are no available dates or times for this service and location.
+          </InlineAlert>
+        </div>
+      ) : (
+        <div className="datetime-selection-panel">
+          <div className="datetime-selection">
+            <section aria-labelledby="datetime-date-heading">
+              <h2 id="datetime-date-heading">Select Date</h2>
+              <Calendar
+                aria-label="Available appointment dates"
+                value={activeDay ? parseDate(activeDay) : null}
+                minValue={parseDate(availableDates[0])}
+                maxValue={parseDate(availableDates[availableDates.length - 1])}
+                defaultFocusedValue={parseDate(availableDates[0])}
+                isDateUnavailable={(date) => !timeSlots[date.toString()]}
+                onChange={(date) => {
+                  const nextDay = date.toString()
+                  if (nextDay !== activeDay) setSelectedSlot(null)
+                  setSelectedDay(nextDay)
+                }}
+              />
+              <ul className="datetime-calendar-legend">
+                <li>
+                  <span className="datetime-calendar-legend-unavailable">Red line</span> — no
+                  appointments available
+                </li>
+                <li>
+                  <span className="datetime-calendar-legend-disabled">Greyed out</span> — outside
+                  the booking window or not selectable
+                </li>
+              </ul>
+            </section>
+
+            <section aria-labelledby="datetime-time-heading">
+              <h2 id="datetime-time-heading">Select Time</h2>
+              {activeDay ? (
+                <div className="datetime-time-panel">
+                  <div className="datetime-time-slots">
+                    <RadioGroup
+                      aria-label={`Available times for ${formatDate(activeDay)}`}
+                      value={selectedSlotValue}
+                      onChange={(value) => {
+                        const slot = activeDaySlots.find(
+                          ({ startTime, endTime }) => slotValue(startTime, endTime) === value,
+                        )
+                        if (slot) setSelectedSlot({ date: activeDay, ...slot })
+                      }}
+                    >
+                      {activeDaySlots.map((slot) => {
+                        const value = slotValue(slot.startTime, slot.endTime)
+                        return (
+                          <Radio key={value} value={value}>
+                            {formatTimeRange(slot.startTime, slot.endTime)}
+                          </Radio>
+                        )
+                      })}
+                    </RadioGroup>
+                  </div>
+                  <p className="datetime-selected-day" aria-live="polite">
+                    {formatDate(activeDay)}
+                  </p>
+                </div>
+              ) : (
+                <Text>Select an available date to see its appointment times.</Text>
+              )}
+            </section>
+          </div>
+        </div>
+      )}
+
+      <div className="booking-nav-row">
+        <BookingBackRow onBack={() => navigate('/login')} />
+      </div>
+    </>
+  )
+}

--- a/appointment-booking/app/routes/datetime.tsx
+++ b/appointment-booking/app/routes/datetime.tsx
@@ -4,8 +4,7 @@ import {
   Calendar,
   Callout,
   InlineAlert,
-  Radio,
-  RadioGroup,
+  Select,
   Text,
 } from '@bcgov/design-system-react-components'
 import { parseDate } from '@internationalized/date'
@@ -250,30 +249,26 @@ export default function DateTimePage() {
               <h2 id="datetime-time-heading">Select Time</h2>
               {activeDay ? (
                 <div className="datetime-time-panel">
+                  <p className="datetime-selected-day" aria-live="polite">
+                    {formatDate(activeDay)}
+                  </p>
                   <div className="datetime-time-slots">
-                    <RadioGroup
+                    <Select
                       aria-label={`Available times for ${formatDate(activeDay)}`}
-                      value={selectedSlotValue}
-                      onChange={(value) => {
+                      placeholder="Select a Time Slot"
+                      selectedKey={selectedSlotValue || null}
+                      items={activeDaySlots.map((slot) => ({
+                        id: slotValue(slot.startTime, slot.endTime),
+                        label: formatTimeRange(slot.startTime, slot.endTime),
+                      }))}
+                      onSelectionChange={(value) => {
                         const slot = activeDaySlots.find(
                           ({ startTime, endTime }) => slotValue(startTime, endTime) === value,
                         )
                         if (slot) setSelectedSlot({ date: activeDay, ...slot })
                       }}
-                    >
-                      {activeDaySlots.map((slot) => {
-                        const value = slotValue(slot.startTime, slot.endTime)
-                        return (
-                          <Radio key={value} value={value}>
-                            {formatTimeRange(slot.startTime, slot.endTime)}
-                          </Radio>
-                        )
-                      })}
-                    </RadioGroup>
+                    />
                   </div>
-                  <p className="datetime-selected-day" aria-live="polite">
-                    {formatDate(activeDay)}
-                  </p>
                 </div>
               ) : (
                 <Text>Select an available date to see its appointment times.</Text>

--- a/appointment-booking/app/routes/login.tsx
+++ b/appointment-booking/app/routes/login.tsx
@@ -153,6 +153,11 @@ export default function LoginPage() {
               </>
             ) : null}
           </Text>
+          {selectedLocation.appointmentMessage ? (
+            <InlineAlert variant="info" title="Location notice">
+              {selectedLocation.appointmentMessage}
+            </InlineAlert>
+          ) : null}
         </div>
       </Callout>
 
@@ -162,8 +167,7 @@ export default function LoginPage() {
 
       <div className="booking-nav-row">
         <BookingBackRow onBack={() => navigate('/service-locations')} />
-        {/* Date/time step is not built yet — Continue stays disabled. */}
-        <BookingContinueRow isDisabled />
+        <BookingContinueRow onContinue={() => navigate('/datetime')} />
       </div>
     </>
   )

--- a/appointment-booking/package-lock.json
+++ b/appointment-booking/package-lock.json
@@ -14,6 +14,7 @@
         "@fortawesome/fontawesome-svg-core": "^7.3.0",
         "@fortawesome/free-solid-svg-icons": "^7.3.0",
         "@fortawesome/react-fontawesome": "^3.3.1",
+        "@internationalized/date": "^3.12.2",
         "@react-router/node": "8.0.0",
         "@react-router/serve": "8.0.0",
         "geolib": "^3.3.14",
@@ -614,6 +615,31 @@
       "integrity": "sha512-kcen18Q/snP6M6JQ6XUQTlWXM1Gnm6y8Zk0i29K+T/Y0m/ab4PufmGpl43l/EJKCnYgpOaZFSXDK7CCO6P0INw==",
       "license": "Apache-2.0"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -621,10 +647,10 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      },
-      "peer": true
+      }
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -6106,31 +6132,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     }
   }

--- a/appointment-booking/package.json
+++ b/appointment-booking/package.json
@@ -21,6 +21,7 @@
     "@fortawesome/fontawesome-svg-core": "^7.3.0",
     "@fortawesome/free-solid-svg-icons": "^7.3.0",
     "@fortawesome/react-fontawesome": "^3.3.1",
+    "@internationalized/date": "^3.12.2",
     "@react-router/node": "8.0.0",
     "@react-router/serve": "8.0.0",
     "geolib": "^3.3.14",


### PR DESCRIPTION
### PR Summary
1. Added booking step 4 at /datetime so signed-in users could pick an available date and time for their selected service and location.
2. Added a small timeslots API client that loaded office slots, mapped dates to YYYY-MM-DD, and kept only bookable times.
3. Persisted the chosen slot in booking context / session storage, cleared it when service or location changed, and enabled Login Continue to reach this step. Review/Continue to step 5 was left out for now.

### Testing Steps

1. Continue from login reaches /datetime and shows available dates/times.
2. Selecting a day and time updates the callout; unavailable dates/times are not selectable.
3. Refresh keeps the slot; changing service/location clears it.
4. Missing auth or service/location shows the existing go-back guards.
5. Check desktop and mobile layout.