### PR TITLE
Refactor date handling in appointment and booking components

### DIFF
--- a/api/app/models/bookings/appointments.py
+++ b/api/app/models/bookings/appointments.py
@@ -15,10 +15,10 @@ limitations under the License.'''
 from app.models.bookings import Base
 from qsystem import db
 from app.utilities.sqlalchemy_compat import UtcDateTime, utcnow
-from sqlalchemy import event, func, or_, and_, text
+from sqlalchemy import event, or_, and_, text
 from datetime import datetime, timedelta, timezone
 from dateutil.parser import parse
-from dateutil import tz
+from app.utilities.timezone_utils import get_timezone, localize, office_day_utc_bounds
 from app.utilities.date_util import current_pacific_time
 from sqlalchemy.orm import declared_attr
 from flask import g
@@ -68,7 +68,9 @@ class Appointment(Base):
     @classmethod
     def find_appointment_availability(cls, office_id: int, timezone:str, first_date: datetime, last_date: datetime):
         """Find appointment availability for dates in a month"""
-        query = db.session.query(Appointment).filter(func.date_trunc('day', func.timezone(timezone, Appointment.start_time)).between(func.date_trunc('day', func.timezone(timezone, first_date)), func.date_trunc('day', func.timezone(timezone, last_date))))
+        start, _ = office_day_utc_bounds(localize(first_date, timezone).date(), timezone)
+        _, end = office_day_utc_bounds(localize(last_date, timezone).date(), timezone)
+        query = db.session.query(Appointment).filter(Appointment.start_time >= start, Appointment.start_time < end)
         query = query.filter(Appointment.office_id == office_id)
         query = query.order_by(Appointment.start_time.asc())
         return query.all()
@@ -78,15 +80,20 @@ class Appointment(Base):
         """Find next day appointments."""
         from app.models.theq import Office, PublicUser, Citizen, Timezone
 
-        tomorrow = current_pacific_time() + timedelta(days=1)
+        now = current_pacific_time()
+        windows = []
+        for office_timezone in db.session.query(Timezone).all():
+            name = office_timezone.timezone_name
+            tomorrow = now.astimezone(get_timezone(name)).date() + timedelta(days=1)
+            start, end = office_day_utc_bounds(tomorrow, name)
+            windows.append(and_(Timezone.timezone_id == office_timezone.timezone_id,
+                                Appointment.start_time >= start, Appointment.start_time < end))
         query = db.session.query(Appointment, Office, Timezone, PublicUser). \
             join(Citizen, Citizen.citizen_id == Appointment.citizen_id). \
             join(Office, Office.office_id == Appointment.office_id). \
             join(Timezone, Timezone.timezone_id == Office.timezone_id). \
             outerjoin(PublicUser, PublicUser.user_id == Citizen.user_id). \
-            filter(func.date_trunc('day',
-                                   func.timezone(Timezone.timezone_name, Appointment.start_time)) ==
-                   tomorrow.strftime("%Y-%m-%d 00:00:00"))
+            filter(or_(*windows) if windows else False)
 
         return query.all()
 
@@ -120,12 +127,14 @@ class Appointment(Base):
         from app.models.theq import PublicUser, Citizen
 
         start_datetime = parse(start_time)
+        day = start_datetime.astimezone(get_timezone(timezone)).date()
+        start, end = office_day_utc_bounds(day, timezone)
         query = db.session.query(Appointment). \
             join(Citizen). \
             join(PublicUser). \
             filter(Appointment.citizen_id == Citizen.citizen_id). \
             filter(Citizen.user_id == PublicUser.user_id). \
-            filter(func.date_trunc('day', func.timezone(timezone, Appointment.start_time)) == (func.date_trunc('day', func.timezone(timezone, start_datetime)))). \
+            filter(Appointment.start_time >= start, Appointment.start_time < end). \
             filter(Appointment.office_id == office_id). \
             filter(PublicUser.username == user_name). \
             filter(Appointment.checked_in_time.is_(None))

--- a/api/app/models/theq/office.py
+++ b/api/app/models/theq/office.py
@@ -17,6 +17,8 @@ from app.models.theq import Base
 from app.models.bookings import Exam, Room
 from qsystem import cache, db
 import enum, logging
+from flask import abort
+from marshmallow import ValidationError
 from sqlalchemy import Enum, desc
 
 
@@ -128,10 +130,15 @@ class Office(Base):
     @classmethod
     def find_by_id(cls, office_id: int):
         """Return a Office by office_id."""
+        if isinstance(office_id, bool) or not isinstance(office_id, (int, str)) or not str(office_id).isdigit():
+            raise ValidationError({"office_id": ["Must be a valid office ID."]})
+        office_id = int(office_id)
         key = Office.format_string % office_id
         office = cache.get(key)
         if not office:
             office = db.session.get(cls, office_id)
+            if office is None:
+                abort(404, description="Office not found.")
             office.timeslots
             office.timezone
         return office
@@ -159,6 +166,14 @@ class Office(Base):
             office_schema = OfficeSchema(many=True)
             active_offices = office_schema.dump(Office.query.filter(Office.deleted.is_(None)).order_by(Office.office_name))
             cache.set(Office.offices_cache_key, active_offices)
+        # Refresh clock rules even when the office reference data was cached
+        # before a deployment or a calendar-year boundary.
+        from datetime import datetime, timezone
+        from app.utilities.timezone_utils import office_clock_offsets
+        for office in active_offices:
+            if office.get('timezone'):
+                office['timezone']['clock_offsets'] = office_clock_offsets(
+                    office['timezone']['timezone_name'], datetime.now(timezone.utc).year)
         return active_offices
 
     @classmethod

--- a/api/app/resources/bookings/appointment/appointment_draft_post.py
+++ b/api/app/resources/bookings/appointment/appointment_draft_post.py
@@ -25,6 +25,7 @@ from app.schemas.theq import CitizenSchema
 from app.services import AvailabilityService
 from app.utilities.auth_util import get_username
 from app.utilities.date_util import add_delta_to_time
+from app.utilities.timezone_utils import convert_local_fields_to_utc
 from qsystem import api, db, my_print, application
 from qsystem import socketio
 
@@ -41,9 +42,10 @@ class AppointmentDraftPost(Resource):
 
         office_id = json_data.get('office_id')
         service_id = json_data.get('service_id')
+        office = Office.find_by_id(office_id)
+        convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
         start_time = parse(json_data.get('start_time'))
         end_time = parse(json_data.get('end_time'))
-        office = Office.find_by_id(office_id)
         service = db.session.get(Service, int(service_id)) if service_id else None
 
         # end_time can be null for CSRs when they click; whereas citizens know end-time.

--- a/api/app/resources/bookings/appointment/appointment_draft_post.py
+++ b/api/app/resources/bookings/appointment/appointment_draft_post.py
@@ -15,6 +15,7 @@ limitations under the License.'''
 import logging
 
 from dateutil.parser import parse
+from marshmallow import ValidationError
 from flask import request, g
 from flask_restx import Resource
 
@@ -24,7 +25,6 @@ from app.schemas.bookings import AppointmentSchema
 from app.schemas.theq import CitizenSchema
 from app.services import AvailabilityService
 from app.utilities.auth_util import get_username
-from app.utilities.date_util import add_delta_to_time
 from app.utilities.timezone_utils import convert_local_fields_to_utc
 from qsystem import api, db, my_print, application
 from qsystem import socketio
@@ -39,18 +39,16 @@ class AppointmentDraftPost(Resource):
     def post(self):
         my_print("==> In AppointmentDraftPost, POST /appointments/draft")
         json_data = request.get_json()
+        if not isinstance(json_data, dict):
+            raise ValidationError({"_schema": ["Must be a JSON object."]})
 
         office_id = json_data.get('office_id')
         service_id = json_data.get('service_id')
         office = Office.find_by_id(office_id)
-        convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
+        convert_local_fields_to_utc(json_data, office.timezone.timezone_name, required=True)
         start_time = parse(json_data.get('start_time'))
         end_time = parse(json_data.get('end_time'))
         service = db.session.get(Service, int(service_id)) if service_id else None
-
-        # end_time can be null for CSRs when they click; whereas citizens know end-time.
-        if not end_time:
-            end_time = add_delta_to_time(start_time, minutes=office.appointment_duration, timezone=office.timezone.timezone_name)
 
         # Unauthenticated requests from citizens won't have name, so we set a fallback
         if (hasattr(g, 'jwt_oidc_token_info') and hasattr(g.jwt_oidc_token_info, 'username')):

--- a/api/app/resources/bookings/appointment/appointment_post.py
+++ b/api/app/resources/bookings/appointment/appointment_post.py
@@ -33,6 +33,7 @@ from qsystem import api, api_call_with_retry, db, my_print, application
 from qsystem import socketio
 from app.auth.auth import jwt
 from app.utilities.sms import send_sms
+from app.utilities.timezone_utils import convert_local_fields_to_utc
 
 
 def _get_valid_service(service_id):
@@ -74,9 +75,6 @@ class AppointmentPost(Resource):
         if (json_data.get('stat_office_id', False)):
             json_data['office_id'] = json_data.get('stat_office_id')
         
-        #get start date:
-        start_time_ct = json_data.get('start_time', False)
-        
         # remove below code, once code is tested - new req --> Stop blackouts from cancelling items (offices will call and cancel people individually if we have to close)
         is_blackout_appt = json_data.get('blackout_flag', 'N') == 'Y'
         csr = None
@@ -101,6 +99,7 @@ class AppointmentPost(Resource):
             citizen.citizen_name = user.display_name
 
             office = Office.find_by_id(office_id)
+            convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
             service = _get_valid_service(service_id)
             if service is None:
                 return {
@@ -128,11 +127,13 @@ class AppointmentPost(Resource):
             csr = CSR.find_by_username(get_username())
             office_id = json_data.get('office_id', csr.office_id)
             office = Office.find_by_id(office_id)
+            convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
 
         else:
             csr = CSR.find_by_username(get_username())
             office_id = csr.office_id
             office = Office.find_by_id(office_id)
+            convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
             service_id = json_data.get('service_id')
 
             # Preserve legacy Newman blackout payloads, which omit service_id for
@@ -151,6 +152,7 @@ class AppointmentPost(Resource):
                     "message": "Could not find service for service_id: " + str(service_id)
                 }, 400
 
+        start_time_ct = json_data.get('start_time', False)
         citizen.office_id = office_id
         citizen.qt_xn_citizen_ind = 0
         citizen_state = CitizenState.query.filter_by(cs_state_name="Appointment booked").first()

--- a/api/app/resources/bookings/appointment/appointment_post.py
+++ b/api/app/resources/bookings/appointment/appointment_post.py
@@ -16,6 +16,7 @@ import logging
 from datetime import datetime
 
 from dateutil.parser import parse
+from marshmallow import ValidationError
 from flask import request
 from flask_restx import Resource
 
@@ -58,6 +59,8 @@ class AppointmentPost(Resource):
     def post(self):
         my_print("==> In AppointmentPost, POST /appointments/")
         json_data = request.get_json()
+        if not isinstance(json_data, dict):
+            raise ValidationError({"_schema": ["Must be a JSON object."]})
         
         if not json_data:
             return {"message": "No input data received for creating an appointment"}, 400
@@ -99,7 +102,7 @@ class AppointmentPost(Resource):
             citizen.citizen_name = user.display_name
 
             office = Office.find_by_id(office_id)
-            convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
+            convert_local_fields_to_utc(json_data, office.timezone.timezone_name, required=True)
             service = _get_valid_service(service_id)
             if service is None:
                 return {
@@ -127,13 +130,13 @@ class AppointmentPost(Resource):
             csr = CSR.find_by_username(get_username())
             office_id = json_data.get('office_id', csr.office_id)
             office = Office.find_by_id(office_id)
-            convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
+            convert_local_fields_to_utc(json_data, office.timezone.timezone_name, required=True)
 
         else:
             csr = CSR.find_by_username(get_username())
             office_id = csr.office_id
             office = Office.find_by_id(office_id)
-            convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
+            convert_local_fields_to_utc(json_data, office.timezone.timezone_name, required=True)
             service_id = json_data.get('service_id')
 
             # Preserve legacy Newman blackout payloads, which omit service_id for

--- a/api/app/resources/bookings/appointment/appointment_put.py
+++ b/api/app/resources/bookings/appointment/appointment_put.py
@@ -28,6 +28,7 @@ from app.services import AvailabilityService
 from dateutil.parser import parse
 from qsystem import socketio, application
 from app.utilities.sms import send_sms
+from app.utilities.timezone_utils import convert_local_fields_to_utc
 
 
 def _get_valid_service(service_id):
@@ -69,6 +70,7 @@ class AppointmentPut(Resource):
         if is_public_user_appt:
             office_id = json_data.get('office_id')
             office = Office.find_by_id(office_id)
+            convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
             appointment = Appointment.query.filter_by(appointment_id=id) \
                 .filter_by(office_id=office_id) \
                 .first_or_404()
@@ -103,6 +105,7 @@ class AppointmentPut(Resource):
             csr = CSR.find_by_username(get_username())
             office_id = csr.office_id
             office = Office.find_by_id(office_id)
+            convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
             if 'service_id' in json_data:
                 service = _get_valid_service(json_data.get('service_id'))
                 if service is None:

--- a/api/app/resources/bookings/appointment/appointment_put.py
+++ b/api/app/resources/bookings/appointment/appointment_put.py
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.'''
 
 import logging
+from marshmallow import ValidationError
 from flask import request, abort
 from flask_restx import Resource
 from qsystem import api, db
@@ -28,7 +29,7 @@ from app.services import AvailabilityService
 from dateutil.parser import parse
 from qsystem import socketio, application
 from app.utilities.sms import send_sms
-from app.utilities.timezone_utils import convert_local_fields_to_utc
+from app.utilities.timezone_utils import convert_local_fields_to_utc, validate_utc_interval
 
 
 def _get_valid_service(service_id):
@@ -50,6 +51,8 @@ class AppointmentPut(Resource):
     @jwt.has_one_of_roles([Role.internal_user.value, Role.online_appointment_user.value])
     def put(self, id):
         json_data = request.get_json()
+        if not isinstance(json_data, dict):
+            raise ValidationError({"_schema": ["Must be a JSON object."]})
         csr = None
         user = None
 
@@ -125,6 +128,7 @@ class AppointmentPut(Resource):
             if citizen.user_id != user.user_id:
                 abort(403)
 
+        validate_utc_interval(json_data, appointment)
         appointment = self.appointment_schema.load(json_data, instance=appointment, partial=True)
         warning = self.appointment_schema.validate(json_data)
 

--- a/api/app/resources/bookings/appointment/appointment_recurring_put.py
+++ b/api/app/resources/bookings/appointment/appointment_recurring_put.py
@@ -21,6 +21,7 @@ from app.models.theq import CSR
 from app.schemas.bookings import AppointmentSchema
 from app.utilities.auth_util import Role, get_username
 from app.auth.auth import jwt
+from app.utilities.timezone_utils import convert_local_fields_to_utc
 
 
 @api.route("/appointments/recurring/<string:id>", methods=["PUT"])
@@ -37,6 +38,8 @@ class AppointmentRecurringPut(Resource):
 
         if not json_data:
             return {"message": "No input data received for updating an series of appointments"}
+
+        convert_local_fields_to_utc(json_data, csr.office.timezone.timezone_name)
 
         appointments = Appointment.query.filter_by(recurring_uuid=id)\
                                   .filter_by(office_id=csr.office_id)\

--- a/api/app/resources/bookings/appointment/appointment_recurring_put.py
+++ b/api/app/resources/bookings/appointment/appointment_recurring_put.py
@@ -17,7 +17,7 @@ from flask import request
 from flask_restx import Resource
 from qsystem import api, db, socketio, application
 from app.models.bookings import Appointment
-from app.models.theq import CSR
+from app.models.theq import CSR, Office
 from app.schemas.bookings import AppointmentSchema
 from app.utilities.auth_util import Role, get_username
 from app.auth.auth import jwt
@@ -39,7 +39,9 @@ class AppointmentRecurringPut(Resource):
         if not json_data:
             return {"message": "No input data received for updating an series of appointments"}
 
-        convert_local_fields_to_utc(json_data, csr.office.timezone.timezone_name)
+        if json_data.get('start_time') or json_data.get('end_time'):
+            office = db.session.get(Office, csr.office_id)
+            convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
 
         appointments = Appointment.query.filter_by(recurring_uuid=id)\
                                   .filter_by(office_id=csr.office_id)\
@@ -55,9 +57,10 @@ class AppointmentRecurringPut(Resource):
                 return {"message": warning}, 422
 
             db.session.add(appointment)
-            db.session.commit()
 
-        result = self.appointment_schema.dump(appointments)
+        db.session.commit()
+
+        result = self.appointment_schema.dump(appointments, many=True)
 
         if not application.config['DISABLE_AUTO_REFRESH']:
             socketio.emit('appointment_update', result, room=csr.office.office_name)

--- a/api/app/resources/bookings/appointment/appointment_recurring_put.py
+++ b/api/app/resources/bookings/appointment/appointment_recurring_put.py
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.'''
 
 import logging
+from marshmallow import ValidationError
 from flask import request
 from flask_restx import Resource
 from qsystem import api, db, socketio, application
@@ -21,7 +22,7 @@ from app.models.theq import CSR, Office
 from app.schemas.bookings import AppointmentSchema
 from app.utilities.auth_util import Role, get_username
 from app.auth.auth import jwt
-from app.utilities.timezone_utils import convert_local_fields_to_utc
+from app.utilities.timezone_utils import convert_local_fields_to_utc, validate_utc_interval
 
 
 @api.route("/appointments/recurring/<string:id>", methods=["PUT"])
@@ -35,11 +36,13 @@ class AppointmentRecurringPut(Resource):
         csr = CSR.find_by_username(get_username())
 
         json_data = request.get_json()
+        if not isinstance(json_data, dict):
+            raise ValidationError({"_schema": ["Must be a JSON object."]})
 
         if not json_data:
             return {"message": "No input data received for updating an series of appointments"}
 
-        if json_data.get('start_time') or json_data.get('end_time'):
+        if 'start_time' in json_data or 'end_time' in json_data:
             office = db.session.get(Office, csr.office_id)
             convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
 
@@ -49,6 +52,7 @@ class AppointmentRecurringPut(Resource):
 
         for appointment in appointments:
 
+            validate_utc_interval(json_data, appointment)
             appointment = self.appointment_schema.load(json_data, instance=appointment, partial=True)
             warning = self.appointment_schema.validate(json_data)
 

--- a/api/app/resources/bookings/booking/booking_post.py
+++ b/api/app/resources/bookings/booking/booking_post.py
@@ -18,10 +18,11 @@ from flask import request
 from app.models.bookings import Room
 from app.schemas.bookings import BookingSchema
 from app.models.bookings import Invigilator
-from app.models.theq import CSR
+from app.models.theq import CSR, Office
 from qsystem import api, api_call_with_retry, db
 from app.utilities.auth_util import Role, get_username
 from app.auth.auth import jwt
+from app.utilities.timezone_utils import convert_local_fields_to_utc
 
 
 @api.route("/bookings/", methods=["POST"])
@@ -42,15 +43,17 @@ class BookingPost(Resource):
         if not json_data:
             return {"message": "No input data received for creating a booking"}, 400
 
+        office_id = json_data.get('office_id') or csr.office_id
+        office = Office.find_by_id(office_id)
+        json_data['office_id'] = office_id
+        convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
+
         booking = self.booking_schema.load(json_data)
         warning = self.booking_schema.validate(json_data)
 
         if warning:
             logging.warning("WARNING: %s", warning)
             return {"message": warning}, 422
-
-        if booking.office_id is None:
-            booking.office_id = csr.office_id
 
         if booking.office_id == csr.office_id or csr.ita2_designate == 1 or json_data.get('for_stat', False):
 

--- a/api/app/resources/bookings/booking/booking_post.py
+++ b/api/app/resources/bookings/booking/booking_post.py
@@ -14,6 +14,7 @@ limitations under the License.'''
 
 import logging
 from flask_restx import Resource
+from marshmallow import ValidationError
 from flask import request
 from app.models.bookings import Room
 from app.schemas.bookings import BookingSchema
@@ -36,6 +37,8 @@ class BookingPost(Resource):
         csr = CSR.find_by_username(get_username())
 
         json_data = request.get_json()
+        if not isinstance(json_data, dict):
+            raise ValidationError({"_schema": ["Must be a JSON object."]})
         i_id = json_data.get('invigilator_id')
         if "room_id" in json_data and json_data["room_id"] == '_offsite':
             json_data["room_id"] = None
@@ -46,7 +49,7 @@ class BookingPost(Resource):
         office_id = json_data.get('office_id') or csr.office_id
         office = Office.find_by_id(office_id)
         json_data['office_id'] = office_id
-        convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
+        convert_local_fields_to_utc(json_data, office.timezone.timezone_name, required=True)
 
         booking = self.booking_schema.load(json_data)
         warning = self.booking_schema.validate(json_data)

--- a/api/app/resources/bookings/booking/booking_put.py
+++ b/api/app/resources/bookings/booking/booking_put.py
@@ -21,6 +21,7 @@ from app.models.theq import CSR
 from app.schemas.bookings import BookingSchema
 from app.utilities.auth_util import Role, get_username
 from app.auth.auth import jwt
+from app.utilities.timezone_utils import convert_local_fields_to_utc
 
 
 @api.route("/bookings/<int:id>/", methods=["PUT"])
@@ -40,6 +41,7 @@ class BookingPut(Resource):
             return {"message": "No input data received for updating a ooking"}
 
         booking = Booking.query.filter_by(booking_id=id).first_or_404()
+        convert_local_fields_to_utc(json_data, booking.office.timezone.timezone_name)
         booking = self.booking_schema.load(json_data, instance=booking, partial=True)
         warning = self.booking_schema.validate(json_data)
 

--- a/api/app/resources/bookings/booking/booking_put.py
+++ b/api/app/resources/bookings/booking/booking_put.py
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.'''
 
 import logging
+from marshmallow import ValidationError
 from flask import request
 from flask_restx import Resource
 from qsystem import api, db
@@ -21,7 +22,7 @@ from app.models.theq import CSR
 from app.schemas.bookings import BookingSchema
 from app.utilities.auth_util import Role, get_username
 from app.auth.auth import jwt
-from app.utilities.timezone_utils import convert_local_fields_to_utc
+from app.utilities.timezone_utils import convert_local_fields_to_utc, validate_utc_interval
 
 
 @api.route("/bookings/<int:id>/", methods=["PUT"])
@@ -35,6 +36,8 @@ class BookingPut(Resource):
         csr = CSR.find_by_username(get_username())
 
         json_data = request.get_json()
+        if not isinstance(json_data, dict):
+            raise ValidationError({"_schema": ["Must be a JSON object."]})
         i_id_list = json_data.get('invigilator_id')
 
         if not json_data:
@@ -42,6 +45,7 @@ class BookingPut(Resource):
 
         booking = Booking.query.filter_by(booking_id=id).first_or_404()
         convert_local_fields_to_utc(json_data, booking.office.timezone.timezone_name)
+        validate_utc_interval(json_data, booking)
         booking = self.booking_schema.load(json_data, instance=booking, partial=True)
         warning = self.booking_schema.validate(json_data)
 

--- a/api/app/resources/bookings/booking/booking_recurring_put.py
+++ b/api/app/resources/bookings/booking/booking_recurring_put.py
@@ -17,7 +17,7 @@ from flask import request
 from flask_restx import Resource
 from qsystem import api, db
 from app.models.bookings import Booking, Room, Invigilator
-from app.models.theq import CSR
+from app.models.theq import CSR, Office
 from app.schemas.bookings import BookingSchema
 from app.utilities.auth_util import Role, get_username
 from app.auth.auth import jwt
@@ -39,7 +39,9 @@ class BookingRecurringPut(Resource):
         if not json_data:
             return {"message": "No input data received for updating recurring bookings"}
 
-        convert_local_fields_to_utc(json_data, csr.office.timezone.timezone_name)
+        if json_data.get('start_time') or json_data.get('end_time'):
+            office = db.session.get(Office, csr.office_id)
+            convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
 
         bookings = Booking.query.filter_by(recurring_uuid=id)\
                                 .filter_by(office_id=csr.office_id)\
@@ -55,9 +57,10 @@ class BookingRecurringPut(Resource):
                 return {"message": warning}, 422
 
             db.session.add(booking)
-            db.session.commit()
 
-        result = self.booking_schema.dump(bookings)
+        db.session.commit()
+
+        result = self.booking_schema.dump(bookings, many=True)
 
         return {
             "bookings": result,

--- a/api/app/resources/bookings/booking/booking_recurring_put.py
+++ b/api/app/resources/bookings/booking/booking_recurring_put.py
@@ -21,6 +21,7 @@ from app.models.theq import CSR
 from app.schemas.bookings import BookingSchema
 from app.utilities.auth_util import Role, get_username
 from app.auth.auth import jwt
+from app.utilities.timezone_utils import convert_local_fields_to_utc
 
 
 @api.route("/bookings/recurring/<string:id>", methods=["PUT"])
@@ -37,6 +38,8 @@ class BookingRecurringPut(Resource):
 
         if not json_data:
             return {"message": "No input data received for updating recurring bookings"}
+
+        convert_local_fields_to_utc(json_data, csr.office.timezone.timezone_name)
 
         bookings = Booking.query.filter_by(recurring_uuid=id)\
                                 .filter_by(office_id=csr.office_id)\

--- a/api/app/resources/bookings/booking/booking_recurring_put.py
+++ b/api/app/resources/bookings/booking/booking_recurring_put.py
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.'''
 
 import logging
+from marshmallow import ValidationError
 from flask import request
 from flask_restx import Resource
 from qsystem import api, db
@@ -21,7 +22,7 @@ from app.models.theq import CSR, Office
 from app.schemas.bookings import BookingSchema
 from app.utilities.auth_util import Role, get_username
 from app.auth.auth import jwt
-from app.utilities.timezone_utils import convert_local_fields_to_utc
+from app.utilities.timezone_utils import convert_local_fields_to_utc, validate_utc_interval
 
 
 @api.route("/bookings/recurring/<string:id>", methods=["PUT"])
@@ -35,11 +36,13 @@ class BookingRecurringPut(Resource):
         csr = CSR.find_by_username(get_username())
 
         json_data = request.get_json()
+        if not isinstance(json_data, dict):
+            raise ValidationError({"_schema": ["Must be a JSON object."]})
 
         if not json_data:
             return {"message": "No input data received for updating recurring bookings"}
 
-        if json_data.get('start_time') or json_data.get('end_time'):
+        if 'start_time' in json_data or 'end_time' in json_data:
             office = db.session.get(Office, csr.office_id)
             convert_local_fields_to_utc(json_data, office.timezone.timezone_name)
 
@@ -49,6 +52,7 @@ class BookingRecurringPut(Resource):
 
         for booking in bookings:
 
+            validate_utc_interval(json_data, booking)
             booking = self.booking_schema.load(json_data, instance=booking, partial=True)
             warning = self.booking_schema.validate(json_data)
 

--- a/api/app/schemas/bookings/appointment_schema.py
+++ b/api/app/schemas/bookings/appointment_schema.py
@@ -17,6 +17,7 @@ from app.models.bookings import Appointment
 from app.schemas.theq import OfficeSchema, ServiceSchema
 from qsystem import ma
 from app.schemas import BaseSchema
+from app.utilities.timezone_utils import office_local_isoformat
 
 
 class AppointmentSchema(BaseSchema):
@@ -31,6 +32,16 @@ class AppointmentSchema(BaseSchema):
     citizen_id = fields.Int()
     start_time = fields.DateTime()
     end_time = fields.DateTime()
+    local_start_time = fields.Function(
+        lambda appointment: office_local_isoformat(
+            appointment.start_time, appointment.office.timezone.timezone_name
+        ), dump_only=True
+    )
+    local_end_time = fields.Function(
+        lambda appointment: office_local_isoformat(
+            appointment.end_time, appointment.office.timezone.timezone_name
+        ), dump_only=True
+    )
     checked_in_time = fields.DateTime()
     comments = fields.String(allow_none=True)
     citizen_name = fields.String()
@@ -42,4 +53,3 @@ class AppointmentSchema(BaseSchema):
     stat_flag = fields.Boolean(allow_none=True)
     office = fields.Nested(OfficeSchema(exclude=('sb', 'counters', 'quick_list', 'back_office_list', 'timeslots')))
     service = fields.Nested(ServiceSchema())
-

--- a/api/app/schemas/bookings/booking_schema.py
+++ b/api/app/schemas/bookings/booking_schema.py
@@ -19,6 +19,7 @@ from app.models.bookings import Booking
 from app.schemas import BaseSchema
 from app.schemas.bookings import RoomSchema, InvigilatorSchema
 from app.schemas.theq import OfficeSchema
+from app.utilities.timezone_utils import office_local_isoformat
 
 
 class BookingSchema(BaseSchema):
@@ -35,6 +36,16 @@ class BookingSchema(BaseSchema):
     fees = fields.Str()
     room_id = fields.Int(allow_none=True)
     start_time = fields.DateTime()
+    local_start_time = fields.Function(
+        lambda booking: office_local_isoformat(
+            booking.start_time, booking.office.timezone.timezone_name
+        ), dump_only=True
+    )
+    local_end_time = fields.Function(
+        lambda booking: office_local_isoformat(
+            booking.end_time, booking.office.timezone.timezone_name
+        ), dump_only=True
+    )
     shadow_invigilator_id = fields.Int(allow_none=True)
     office_id = fields.Int()
     sbc_staff_invigilated = fields.Int()

--- a/api/app/schemas/theq/timezone_schema.py
+++ b/api/app/schemas/theq/timezone_schema.py
@@ -12,7 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.'''
 
+from datetime import datetime, timezone
 from marshmallow import fields
+from app.utilities.timezone_utils import office_clock_offsets
 from app.models.theq import Timezone
 from qsystem import ma
 from app.schemas import BaseSchema
@@ -26,3 +28,7 @@ class TimezoneSchema(BaseSchema):
 
     timezone_id = fields.Int()
     timezone_name = fields.Str()
+
+    clock_offsets = fields.Function(
+        lambda zone: office_clock_offsets(zone.timezone_name, datetime.now(timezone.utc).year)
+    )

--- a/api/app/tests/api_test_support.py
+++ b/api/app/tests/api_test_support.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from datetime import datetime, time, timedelta, timezone
 from typing import Any, Optional
 from uuid import uuid4
-from zoneinfo import ZoneInfo
 
 
 @dataclass
@@ -98,13 +97,10 @@ def slot_window_to_iso(
     day_key: str, slot: dict[str, Any], timezone_name: str
 ) -> tuple[str, str]:
     day_value = datetime.strptime(day_key, "%m/%d/%Y").date()
-    timezone = ZoneInfo(timezone_name)
     start_hour, start_minute = [int(part) for part in slot["start_time"].split(":")]
     end_hour, end_minute = [int(part) for part in slot["end_time"].split(":")]
-    start_dt = datetime.combine(
-        day_value, time(start_hour, start_minute), tzinfo=timezone
-    )
-    end_dt = datetime.combine(day_value, time(end_hour, end_minute), tzinfo=timezone)
+    start_dt = datetime.combine(day_value, time(start_hour, start_minute))
+    end_dt = datetime.combine(day_value, time(end_hour, end_minute))
     return start_dt.isoformat(), end_dt.isoformat()
 
 
@@ -116,7 +112,7 @@ def future_utc_window(
     )
     start_dt = start_dt + timedelta(days=days_from_now)
     end_dt = start_dt + timedelta(minutes=duration_minutes)
-    return start_dt.isoformat(), end_dt.isoformat()
+    return start_dt.replace(tzinfo=None).isoformat(), end_dt.replace(tzinfo=None).isoformat()
 
 
 def unique_name(prefix: str) -> str:

--- a/api/app/tests/contracts/schemas.py
+++ b/api/app/tests/contracts/schemas.py
@@ -6,6 +6,10 @@ ISO_DATETIME_SCHEMA = {
     "type": "string",
     "pattern": r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:(?:Z|[+-]\d{2}:\d{2}))?$",
 }
+LOCAL_DATETIME_SCHEMA = {
+    "type": "string",
+    "pattern": r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?$",
+}
 DATE_KEY_SCHEMA = {"type": "string", "pattern": r"^\d{2}/\d{2}/\d{4}$"}
 
 
@@ -438,6 +442,8 @@ APPOINTMENT_SCHEMA = object_schema(
         "office_id",
         "start_time",
         "end_time",
+        "local_start_time",
+        "local_end_time",
         "citizen_name",
     ],
     properties={
@@ -447,6 +453,8 @@ APPOINTMENT_SCHEMA = object_schema(
         "citizen_id": nullable({"type": "integer"}),
         "start_time": nullable(ISO_DATETIME_SCHEMA),
         "end_time": nullable(ISO_DATETIME_SCHEMA),
+        "local_start_time": nullable(LOCAL_DATETIME_SCHEMA),
+        "local_end_time": nullable(LOCAL_DATETIME_SCHEMA),
         "checked_in_time": nullable(ISO_DATETIME_SCHEMA),
         "comments": nullable({"type": "string"}),
         "citizen_name": {"type": "string"},
@@ -462,7 +470,15 @@ APPOINTMENT_SCHEMA = object_schema(
 )
 
 BOOKING_SCHEMA = object_schema(
-    required=["booking_id", "office_id", "start_time", "end_time", "invigilators"],
+    required=[
+        "booking_id",
+        "office_id",
+        "start_time",
+        "end_time",
+        "local_start_time",
+        "local_end_time",
+        "invigilators",
+    ],
     properties={
         "booking_id": {"type": "integer"},
         "booking_name": nullable({"type": "string"}),
@@ -470,6 +486,8 @@ BOOKING_SCHEMA = object_schema(
         "fees": nullable({"type": "string"}),
         "room_id": nullable({"type": "integer"}),
         "start_time": nullable(ISO_DATETIME_SCHEMA),
+        "local_start_time": nullable(LOCAL_DATETIME_SCHEMA),
+        "local_end_time": nullable(LOCAL_DATETIME_SCHEMA),
         "shadow_invigilator_id": nullable({"type": "integer"}),
         "office_id": {"type": "integer"},
         "sbc_staff_invigilated": nullable({"type": "integer"}),

--- a/api/app/tests/contracts/schemas.py
+++ b/api/app/tests/contracts/schemas.py
@@ -27,10 +27,16 @@ def object_schema(*, required, properties, additional_properties=False):
 
 
 TIMEZONE_SCHEMA = object_schema(
-    required=["timezone_id", "timezone_name"],
+    required=["timezone_id", "timezone_name", "clock_offsets"],
     properties={
         "timezone_id": {"type": "integer"},
         "timezone_name": {"type": "string"},
+        "clock_offsets": {"type": "array", "minItems": 1, "items": object_schema(
+            required=["start", "end", "offset_seconds"], properties={
+                "start": {"type": "string", "format": "date-time"},
+                "end": {"type": "string", "format": "date-time"},
+                "offset_seconds": {"type": "integer"},
+            })},
     },
 )
 

--- a/api/app/tests/contracts/test_appointment_contracts.py
+++ b/api/app/tests/contracts/test_appointment_contracts.py
@@ -1,4 +1,5 @@
 import pytest
+from app.utilities.timezone_utils import local_datetime_to_utc
 from app.tests.api_test_support import (
     assert_json_response,
     first_day_with_slots,
@@ -57,7 +58,16 @@ def test_appointment_create_response_matches_the_contract(
 
     assert_json_response(response, 201)
     validate_schema(body, APPOINTMENT_RESPONSE_SCHEMA)
-    assert body["appointment"]["citizen_name"]
+    appointment = body["appointment"]
+    assert appointment["citizen_name"]
+    assert appointment["local_start_time"] == start_time
+    assert appointment["local_end_time"] == end_time
+    assert appointment["start_time"] == local_datetime_to_utc(
+        start_time, seeded_data["office_timezones"]["test_office"]
+    ).isoformat()
+    assert appointment["end_time"] == local_datetime_to_utc(
+        end_time, seeded_data["office_timezones"]["test_office"]
+    ).isoformat()
 
 
 def test_appointment_detail_response_matches_the_contract(

--- a/api/app/tests/contracts/test_booking_contracts.py
+++ b/api/app/tests/contracts/test_booking_contracts.py
@@ -1,4 +1,5 @@
 import pytest
+from app.utilities.timezone_utils import local_datetime_to_utc
 from app.tests.api_test_support import (
     assert_json_response,
     future_utc_window,
@@ -50,7 +51,16 @@ def test_booking_create_response_matches_the_contract(internal_ga_client, seeded
 
     assert_json_response(response, 201)
     validate_schema(body, BOOKING_RESPONSE_SCHEMA)
-    assert body["booking"]["invigilators"] == [seeded_data["invigilator_ids"][0]]
+    booking = body["booking"]
+    assert booking["invigilators"] == [seeded_data["invigilator_ids"][0]]
+    assert booking["local_start_time"] == start_time
+    assert booking["local_end_time"] == end_time
+    assert booking["start_time"] == local_datetime_to_utc(
+        start_time, seeded_data["office_timezones"]["test_office"]
+    ).isoformat()
+    assert booking["end_time"] == local_datetime_to_utc(
+        end_time, seeded_data["office_timezones"]["test_office"]
+    ).isoformat()
 
 
 def test_booking_detail_response_matches_the_contract(internal_ga_client, seeded_data):

--- a/api/app/tests/flows/test_appointment_flows.py
+++ b/api/app/tests/flows/test_appointment_flows.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import uuid4
 
 import pytest
+from app.utilities.timezone_utils import local_datetime_to_utc
 from app.tests.api_test_support import (
     assert_json_response,
     create_public_user,
@@ -64,19 +66,31 @@ def test_internal_appointment_can_be_listed_and_retrieved(
 
 
 def test_internal_appointment_can_be_updated(internal_ga_client, seeded_data):
-    """Assert that internal appointments preserve comment updates."""
+    """Assert that internal appointments convert and return local time updates."""
     appointment = _create_internal_appointment(
         internal_ga_client, seeded_data, days_from_now=2
     )
+    start_time, end_time = future_utc_window(3)
 
     response = internal_ga_client.put(
         f"/appointments/{appointment['appointment_id']}/",
-        json={"comments": "Internal appointment updated"},
+        json={
+            "comments": "Internal appointment updated",
+            "start_time": start_time,
+            "end_time": end_time,
+        },
     )
 
     assert_json_response(response, 200)
-    assert (
-        json_of(response)["appointment"]["comments"] == "Internal appointment updated"
+    updated = json_of(response)["appointment"]
+    assert updated["comments"] == "Internal appointment updated"
+    assert updated["local_start_time"] == start_time
+    assert updated["local_end_time"] == end_time
+    assert datetime.fromisoformat(updated["start_time"]) == local_datetime_to_utc(
+        start_time, seeded_data["office_timezones"]["test_office"]
+    )
+    assert datetime.fromisoformat(updated["end_time"]) == local_datetime_to_utc(
+        end_time, seeded_data["office_timezones"]["test_office"]
     )
 
 

--- a/api/app/tests/flows/test_booking_exam_flows.py
+++ b/api/app/tests/flows/test_booking_exam_flows.py
@@ -5,8 +5,10 @@ from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 import pytest
+from app.utilities.timezone_utils import local_datetime_to_utc
 from app.tests.api_test_support import (
     assert_json_response,
+    future_utc_window,
     json_of,
 )
 from app.tests.api_test_support import (
@@ -36,8 +38,9 @@ def test_booking_can_be_listed_and_retrieved(internal_ga_client, seeded_data):
 
 
 def test_booking_can_be_updated(internal_ga_client, seeded_data):
-    """Assert that booking updates preserve editable booking fields."""
+    """Assert that booking updates convert and return office-local times."""
     booking = _create_booking(internal_ga_client, seeded_data, days_from_now=2)
+    start_time, end_time = future_utc_window(3, duration_minutes=120)
 
     response = internal_ga_client.put(
         f"/bookings/{booking['booking_id']}/",
@@ -45,11 +48,22 @@ def test_booking_can_be_updated(internal_ga_client, seeded_data):
             "booking_name": "Updated single booking",
             "booking_contact_information": "updated-booking@example.com",
             "invigilator_id": [seeded_data["invigilator_ids"][1]],
+            "start_time": start_time,
+            "end_time": end_time,
         },
     )
 
     assert_json_response(response, 200)
-    assert json_of(response)["booking"]["booking_name"] == "Updated single booking"
+    updated = json_of(response)["booking"]
+    assert updated["booking_name"] == "Updated single booking"
+    assert updated["local_start_time"] == start_time
+    assert updated["local_end_time"] == end_time
+    assert datetime.fromisoformat(updated["start_time"]) == local_datetime_to_utc(
+        start_time, seeded_data["office_timezones"]["test_office"]
+    )
+    assert datetime.fromisoformat(updated["end_time"]) == local_datetime_to_utc(
+        end_time, seeded_data["office_timezones"]["test_office"]
+    )
 
 
 def test_booking_can_be_deleted(internal_ga_client, seeded_data):

--- a/api/app/tests/flows/test_timezone_regressions.py
+++ b/api/app/tests/flows/test_timezone_regressions.py
@@ -1,0 +1,204 @@
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+from app.tests.api_test_support import (
+    create_booking,
+    create_internal_appointment,
+    create_public_user,
+    json_of,
+)
+
+pytestmark = [pytest.mark.integration, pytest.mark.usefixtures("seeded_database")]
+
+
+@pytest.mark.parametrize(
+    "resource",
+    [
+        "appointments",
+        "bookings",
+        "draft",
+        "appointment_edit",
+        "booking_edit",
+        "appointment_series",
+        "booking_series",
+    ],
+)
+@pytest.mark.parametrize("bad_value", ["not-a-date", None, 42, "", False])
+def test_scheduling_routes_return_field_validation_errors(
+    internal_ga_client,
+    seeded_data,
+    resource,
+    bad_value,
+):
+    client = internal_ga_client
+    payload = {
+        "office_id": seeded_data["office_ids"]["test_office"],
+        "start_time": bad_value,
+        "end_time": "2026-12-01T09:30:00",
+        "citizen_name": "Timezone QA",
+        "booking_name": "Timezone QA",
+        "service_id": seeded_data["service_ids"]["msp"],
+    }
+    method = client.post
+    path = f"/{resource}/"
+    if resource == "draft":
+        path = "/appointments/draft"
+    elif resource.endswith("_edit") or resource.endswith("_series"):
+        appointment = resource.startswith("appointment")
+        kind = "appointments" if appointment else "bookings"
+        record = (create_internal_appointment if appointment else create_booking)(
+            client, seeded_data, days_from_now=2
+        )
+        record_id = record["appointment_id" if appointment else "booking_id"]
+        method = client.put
+        path = f"/{kind}/{record_id}/"
+        if resource.endswith("_series"):
+            series = str(uuid4())
+            assert client.put(path, json={"recurring_uuid": series}).status_code == 200
+            path = f"/{kind}/recurring/{series}"
+    response = method(path, json=payload)
+    assert response.status_code == 422, response.get_data(as_text=True)
+    assert "start_time" in json_of(response)["message"]
+
+
+@pytest.mark.parametrize(
+    "creator,kind,id_key",
+    [
+        (create_booking, "bookings", "booking_id"),
+        (create_internal_appointment, "appointments", "appointment_id"),
+    ],
+)
+def test_partial_end_edit_cannot_reverse_interval(
+    internal_ga_client, seeded_data, creator, kind, id_key
+):
+    record = creator(internal_ga_client, seeded_data, days_from_now=2)
+    path = f"/{kind}/{record[id_key]}/"
+    response = internal_ga_client.put(
+        path, json={"end_time": record["local_start_time"]}
+    )
+    assert response.status_code == 422
+    saved = json_of(internal_ga_client.get(path))[
+        "booking" if kind == "bookings" else "appointment"
+    ]
+    assert saved["end_time"] == record["end_time"]
+
+
+def test_date_queries_use_api_rules_not_postgres_rules(
+    app,
+    internal_ga_client,
+    public_client,
+    seeded_data,
+    monkeypatch,
+):
+    """The synthetic zone is deliberately unknown to PostgreSQL."""
+    from app.models.bookings import Appointment
+    from app.models.theq import Citizen, Office, Timezone
+    from app.utilities import timezone_utils
+    from app.models.bookings import appointments as model
+    from qsystem import db
+
+    user = create_public_user(public_client)
+    records = [
+        create_internal_appointment(internal_ga_client, seeded_data, days_from_now=2)
+        for _ in range(4)
+    ]
+    ids = {record["appointment_id"] for record in records}
+    original_timezone = timezone_utils.get_timezone
+
+    def pinned_zone(name):
+        return original_timezone("America/Vancouver" if name == "QA/APIOnly" else name)
+
+    monkeypatch.setattr(timezone_utils, "get_timezone", pinned_zone)
+    monkeypatch.setattr(model, "get_timezone", pinned_zone)
+    monkeypatch.setattr(
+        model,
+        "current_pacific_time",
+        lambda: datetime(2026, 11, 30, 20, tzinfo=timezone.utc),
+    )
+
+    with app.app_context():
+        office_id = seeded_data["office_ids"]["test_office"]
+        zone = Timezone(timezone_name="QA/APIOnly")
+        db.session.add(zone)
+        db.session.flush()
+        db.session.get(Office, office_id).timezone_id = zone.timezone_id
+        starts = [
+            "2026-12-01T06:59:00+00:00",
+            "2026-12-01T07:00:00+00:00",
+            "2026-12-02T06:59:00+00:00",
+            "2026-12-02T07:00:00+00:00",
+        ]
+        for record, start in zip(records, starts):
+            row = db.session.get(Appointment, record["appointment_id"])
+            row.start_time = datetime.fromisoformat(start)
+            row.end_time = row.start_time + timedelta(minutes=30)
+            db.session.get(Citizen, row.citizen_id).user_id = user["user_id"]
+        db.session.commit()
+        expected = {records[1]["appointment_id"], records[2]["appointment_id"]}
+        day = datetime(2026, 12, 1, 16, tzinfo=timezone.utc)
+        available = Appointment.find_appointment_availability(
+            office_id, "QA/APIOnly", day, day
+        )
+        assert {row.appointment_id for row in available} & ids == expected
+        duplicates = Appointment.find_by_username_and_office_id(
+            office_id, "theq-public-user@bceid", day.isoformat(), "QA/APIOnly"
+        )
+        assert {row.appointment_id for row in duplicates} & ids == expected
+        reminders = Appointment.find_next_day_appointments()
+        assert {row[0].appointment_id for row in reminders} & ids == expected
+
+
+def test_reminders_use_each_offices_tomorrow_at_midnight(
+    app,
+    internal_ga_client,
+    seeded_data,
+    monkeypatch,
+):
+    from app.models.bookings import Appointment
+    from app.models.bookings import appointments as model
+    from app.models.theq import Office, Timezone
+    from qsystem import db
+
+    records = [
+        create_internal_appointment(internal_ga_client, seeded_data, days_from_now=2)
+        for _ in range(3)
+    ]
+    monkeypatch.setattr(
+        model,
+        "current_pacific_time",
+        lambda: datetime(2026, 11, 30, 6, 30, tzinfo=timezone.utc),
+    )
+    with app.app_context():
+        vancouver = db.session.get(Office, seeded_data["office_ids"]["test_office"])
+        cranbrook = db.session.get(Office, seeded_data["office_ids"]["limited_office"])
+        for office, name in [
+            (vancouver, "America/Vancouver"),
+            (cranbrook, "America/Edmonton"),
+        ]:
+            zone = Timezone.query.filter_by(timezone_name=name).first()
+            if zone is None:
+                zone = Timezone(timezone_name=name)
+                db.session.add(zone)
+                db.session.flush()
+            office.timezone_id = zone.timezone_id
+        for record, office, start in zip(
+            records,
+            [vancouver, cranbrook, cranbrook],
+            [
+                "2026-11-30T16:00:00+00:00",
+                "2026-12-01T15:00:00+00:00",
+                "2026-11-30T15:00:00+00:00",
+            ],
+        ):
+            row = db.session.get(Appointment, record["appointment_id"])
+            row.office_id = office.office_id
+            row.start_time = datetime.fromisoformat(start)
+            row.end_time = row.start_time + timedelta(minutes=30)
+        db.session.commit()
+        ids = {record["appointment_id"] for record in records}
+        actual = {
+            row[0].appointment_id for row in Appointment.find_next_day_appointments()
+        } & ids
+        assert actual == {records[0]["appointment_id"], records[1]["appointment_id"]}

--- a/api/app/tests/test_timezone_utils.py
+++ b/api/app/tests/test_timezone_utils.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timezone
+
+import pytest
+from marshmallow import ValidationError
+
+from app.utilities.timezone_utils import (
+    local_datetime_to_utc,
+    office_local_isoformat,
+)
+
+
+@pytest.mark.parametrize(
+    ("local_value", "expected_utc"),
+    [
+        ("2026-03-07T12:00:00", datetime(2026, 3, 7, 20, tzinfo=timezone.utc)),
+        ("2026-03-08T12:00:00", datetime(2026, 3, 8, 19, tzinfo=timezone.utc)),
+        ("2026-12-01T12:00:00", datetime(2026, 12, 1, 19, tzinfo=timezone.utc)),
+    ],
+)
+def test_vancouver_uses_permanent_utc_minus_seven_after_march_8(
+    local_value, expected_utc
+):
+    assert local_datetime_to_utc(local_value, "America/Vancouver") == expected_utc
+
+
+def test_dawson_creek_remains_utc_minus_seven():
+    assert local_datetime_to_utc(
+        "2026-01-15T12:00:00", "America/Dawson_Creek"
+    ) == datetime(2026, 1, 15, 19, tzinfo=timezone.utc)
+
+
+def test_local_response_value_has_no_offset():
+    assert office_local_isoformat(
+        datetime(2026, 12, 1, 19, tzinfo=timezone.utc), "America/Vancouver"
+    ) == "2026-12-01T12:00:00"
+
+
+def test_aware_input_is_rejected():
+    with pytest.raises(ValidationError, match="without a UTC offset"):
+        local_datetime_to_utc("2026-12-01T19:00:00Z", "America/Vancouver")

--- a/api/app/tests/test_timezone_utils.py
+++ b/api/app/tests/test_timezone_utils.py
@@ -30,11 +30,106 @@ def test_dawson_creek_remains_utc_minus_seven():
 
 
 def test_local_response_value_has_no_offset():
-    assert office_local_isoformat(
-        datetime(2026, 12, 1, 19, tzinfo=timezone.utc), "America/Vancouver"
-    ) == "2026-12-01T12:00:00"
+    assert (
+        office_local_isoformat(
+            datetime(2026, 12, 1, 19, tzinfo=timezone.utc), "America/Vancouver"
+        )
+        == "2026-12-01T12:00:00"
+    )
 
 
 def test_aware_input_is_rejected():
     with pytest.raises(ValidationError, match="without a UTC offset"):
         local_datetime_to_utc("2026-12-01T19:00:00Z", "America/Vancouver")
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["not-a-date", "2026-02-30T09:00:00", "2026-12-01", "", None, 123, True, [], {}],
+)
+def test_malformed_local_values_raise_validation_errors(value):
+    with pytest.raises(ValidationError):
+        local_datetime_to_utc(value, "America/Vancouver")
+
+
+def test_scheduling_conversion_is_atomic_and_reports_field():
+    from app.utilities.timezone_utils import convert_local_fields_to_utc
+
+    payload = {"start_time": "2026-12-01T09:00:00", "end_time": "bad"}
+    original = payload.copy()
+    with pytest.raises(ValidationError) as error:
+        convert_local_fields_to_utc(payload, "America/Vancouver")
+    assert "end_time" in error.value.messages
+    assert payload == original
+
+
+@pytest.mark.parametrize(
+    "value,zone",
+    [
+        ("2026-03-08T02:30:00", "America/Vancouver"),
+        ("2025-11-02T01:30:00", "America/Edmonton"),
+    ],
+)
+def test_nonexistent_and_ambiguous_times_are_rejected(value, zone):
+    with pytest.raises(ValidationError):
+        local_datetime_to_utc(value, zone)
+
+
+def test_partial_interval_validation_uses_existing_endpoint():
+    from types import SimpleNamespace
+    from app.utilities.timezone_utils import validate_utc_interval
+
+    existing = SimpleNamespace(
+        start_time=datetime(2026, 12, 1, 16, tzinfo=timezone.utc),
+        end_time=datetime(2026, 12, 1, 17, tzinfo=timezone.utc),
+    )
+    with pytest.raises(ValidationError):
+        validate_utc_interval({"end_time": "2026-12-01T15:00:00+00:00"}, existing)
+    validate_utc_interval({"comments": "unchanged time"}, existing)
+
+
+@pytest.mark.parametrize(
+    "day,zone,start,end",
+    [
+        (
+            "2026-12-01",
+            "America/Vancouver",
+            "2026-12-01T07:00:00+00:00",
+            "2026-12-02T07:00:00+00:00",
+        ),
+        (
+            "2026-12-01",
+            "America/Edmonton",
+            "2026-12-01T06:00:00+00:00",
+            "2026-12-02T06:00:00+00:00",
+        ),
+        (
+            "2026-03-08",
+            "America/Vancouver",
+            "2026-03-08T08:00:00+00:00",
+            "2026-03-09T07:00:00+00:00",
+        ),
+    ],
+)
+def test_office_day_boundaries_use_pinned_rules(day, zone, start, end):
+    from datetime import date
+    from app.utilities.timezone_utils import office_day_utc_bounds
+
+    actual = office_day_utc_bounds(date.fromisoformat(day), zone)
+    assert [value.isoformat() for value in actual] == [start, end]
+
+
+def test_clock_offsets_preserve_transition_in_cached_response():
+    from app.utilities.timezone_utils import office_clock_offsets
+
+    periods = office_clock_offsets("America/Vancouver", 2026)
+
+    def offset(instant):
+        return next(
+            p["offset_seconds"] for p in periods if p["start"] <= instant < p["end"]
+        )
+
+    assert offset("2026-03-08T09:59:59+00:00") == -8 * 3600
+    assert offset("2026-03-08T10:00:00+00:00") == -7 * 3600
+    assert offset("2026-12-01T16:00:00+00:00") == -7 * 3600
+    assert offset("2027-07-15T16:00:00+00:00") == -7 * 3600

--- a/api/app/tests/validation/test_appointment_validation.py
+++ b/api/app/tests/validation/test_appointment_validation.py
@@ -79,8 +79,8 @@ def test_public_appointment_update_rejects_moving_onto_another_users_slot(
             "comments": "Move into a conflicting slot",
             "office_id": other_appointment["office_id"],
             "service_id": other_appointment["service_id"],
-            "start_time": taken_appointment["start_time"],
-            "end_time": taken_appointment["end_time"],
+            "start_time": taken_appointment["local_start_time"],
+            "end_time": taken_appointment["local_end_time"],
         },
     )
 

--- a/api/app/utilities/timezone_utils.py
+++ b/api/app/utilities/timezone_utils.py
@@ -1,15 +1,23 @@
-"""Timezone helpers built on Python's stdlib zoneinfo support."""
+"""Timezone helpers backed by the application's pinned IANA database."""
 
 from datetime import datetime, timezone
+from functools import lru_cache
+from importlib.resources import files
 from zoneinfo import ZoneInfo
+
+from dateutil.parser import parse
+from marshmallow import ValidationError
 
 
 UTC = timezone.utc
 
 
+@lru_cache(maxsize=None)
 def get_timezone(timezone_name: str) -> ZoneInfo:
-    """Return a ZoneInfo instance for the given timezone name."""
-    return ZoneInfo(timezone_name)
+    """Return a zone from the application's pinned tzdata package."""
+    zone_path = files("tzdata.zoneinfo").joinpath(*timezone_name.split("/"))
+    with zone_path.open("rb") as zone_file:
+        return ZoneInfo.from_file(zone_file, key=timezone_name)
 
 
 def localize(value: datetime, timezone_name: str) -> datetime:
@@ -25,3 +33,26 @@ def as_utc(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=UTC)
     return value.astimezone(UTC)
+
+
+def local_datetime_to_utc(value: str | datetime, timezone_name: str) -> datetime:
+    """Interpret an offset-less office wall time and return the UTC instant."""
+    parsed = parse(value) if isinstance(value, str) else value
+    if parsed.tzinfo is not None:
+        raise ValidationError("Must be an office-local datetime without a UTC offset.")
+    return localize(parsed, timezone_name).astimezone(UTC)
+
+
+def convert_local_fields_to_utc(data: dict, timezone_name: str) -> dict:
+    """Convert scheduling fields in a request payload from office time to UTC."""
+    for field_name in ("start_time", "end_time"):
+        if data.get(field_name) not in (None, ""):
+            data[field_name] = local_datetime_to_utc(data[field_name], timezone_name).isoformat()
+    return data
+
+
+def office_local_isoformat(value: datetime | None, timezone_name: str) -> str | None:
+    """Serialize a UTC instant as an offset-less office-local wall time."""
+    if value is None:
+        return None
+    return as_utc(value).astimezone(get_timezone(timezone_name)).replace(tzinfo=None).isoformat()

--- a/api/app/utilities/timezone_utils.py
+++ b/api/app/utilities/timezone_utils.py
@@ -1,11 +1,12 @@
 """Timezone helpers backed by the application's pinned IANA database."""
 
-from datetime import datetime, timezone
+import re
+
+from datetime import date, datetime, time, timedelta, timezone
 from functools import lru_cache
 from importlib.resources import files
 from zoneinfo import ZoneInfo
 
-from dateutil.parser import parse
 from marshmallow import ValidationError
 
 
@@ -37,22 +38,135 @@ def as_utc(value: datetime) -> datetime:
 
 def local_datetime_to_utc(value: str | datetime, timezone_name: str) -> datetime:
     """Interpret an offset-less office wall time and return the UTC instant."""
-    parsed = parse(value) if isinstance(value, str) else value
+    try:
+        if isinstance(value, str):
+            if not re.fullmatch(
+                r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?",
+                value,
+            ):
+                raise ValueError()
+            parsed = datetime.fromisoformat(value)
+        elif isinstance(value, datetime):
+            parsed = value
+        else:
+            raise ValueError()
+    except (ValueError, TypeError, OverflowError) as error:
+        raise ValidationError(
+            "Must be a valid office-local datetime (YYYY-MM-DDTHH:mm:ss)."
+        ) from error
     if parsed.tzinfo is not None:
         raise ValidationError("Must be an office-local datetime without a UTC offset.")
-    return localize(parsed, timezone_name).astimezone(UTC)
+    localized = localize(parsed, timezone_name)
+    result = localized.astimezone(UTC)
+    if result.astimezone(localized.tzinfo).replace(tzinfo=None) != parsed:
+        raise ValidationError("This local time does not exist in the office time zone.")
+    if localized.replace(fold=1).utcoffset() != localized.replace(fold=0).utcoffset():
+        raise ValidationError("This local time is ambiguous in the office time zone.")
+    return result
 
 
-def convert_local_fields_to_utc(data: dict, timezone_name: str) -> dict:
+def convert_local_fields_to_utc(
+    data: dict, timezone_name: str, *, required: bool = False
+) -> dict:
     """Convert scheduling fields in a request payload from office time to UTC."""
+    if not isinstance(data, dict):
+        raise ValidationError("Must be a JSON object.")
+    if required:
+        missing = {
+            name: ["Missing data for required field."]
+            for name in ("start_time", "end_time")
+            if name not in data
+        }
+        if missing:
+            raise ValidationError(missing)
+    converted = {}
     for field_name in ("start_time", "end_time"):
-        if data.get(field_name) not in (None, ""):
-            data[field_name] = local_datetime_to_utc(data[field_name], timezone_name).isoformat()
+        if field_name in data:
+            try:
+                converted[field_name] = local_datetime_to_utc(
+                    data[field_name], timezone_name
+                ).isoformat()
+            except ValidationError as error:
+                raise ValidationError({field_name: error.messages}) from error
+    validate_utc_interval(converted)
+    data.update(converted)
     return data
+
+
+def validate_utc_interval(data: dict, instance=None) -> None:
+    """Validate partial edits against persisted endpoints before mutating the row."""
+    if not any(name in data for name in ("start_time", "end_time")):
+        return
+    start = data.get("start_time", getattr(instance, "start_time", None))
+    end = data.get("end_time", getattr(instance, "end_time", None))
+    if start is not None and end is not None:
+        start = datetime.fromisoformat(start) if isinstance(start, str) else start
+        end = datetime.fromisoformat(end) if isinstance(end, str) else end
+        if as_utc(end) <= as_utc(start):
+            raise ValidationError({"end_time": ["Must be after start_time."]})
+
+
+def office_day_utc_bounds(day: date, timezone_name: str) -> tuple[datetime, datetime]:
+    """UTC half-open boundaries for a calendar day, using only pinned rules."""
+    zone = get_timezone(timezone_name)
+    return (
+        datetime.combine(day, time.min, zone).astimezone(UTC),
+        datetime.combine(day + timedelta(days=1), time.min, zone).astimezone(UTC),
+    )
+
+
+@lru_cache(maxsize=128)
+def office_clock_offsets(timezone_name: str, year: int) -> list[dict]:
+    """Clock-only offset periods, including transitions, safe to cache on clients.
+
+    Three calendar years cover long-lived tabs without using browser tzdata.
+    Scheduling dates themselves continue to be converted exclusively by the API.
+    """
+    zone = get_timezone(timezone_name)
+    start = datetime(year - 1, 1, 1, tzinfo=UTC)
+    end = datetime(year + 2, 1, 1, tzinfo=UTC)
+
+    def offset(instant):
+        return int(instant.astimezone(zone).utcoffset().total_seconds())
+
+    periods = [
+        {
+            "start": start.isoformat(),
+            "end": end.isoformat(),
+            "offset_seconds": offset(start),
+        }
+    ]
+    cursor = start
+    while cursor < end:
+        following = min(cursor + timedelta(days=1), end)
+        if offset(following) != offset(cursor):
+            low, high = int(cursor.timestamp()), int(following.timestamp())
+            while high - low > 1:
+                middle = (low + high) // 2
+                if offset(datetime.fromtimestamp(middle, UTC)) == offset(cursor):
+                    low = middle
+                else:
+                    high = middle
+            transition = datetime.fromtimestamp(high, UTC)
+            periods[-1]["end"] = transition.isoformat()
+            periods.append(
+                {
+                    "start": transition.isoformat(),
+                    "end": end.isoformat(),
+                    "offset_seconds": offset(transition),
+                }
+            )
+        cursor = following
+    return periods
 
 
 def office_local_isoformat(value: datetime | None, timezone_name: str) -> str | None:
     """Serialize a UTC instant as an offset-less office-local wall time."""
     if value is None:
         return None
-    return as_utc(value).astimezone(get_timezone(timezone_name)).replace(tzinfo=None).isoformat()
+    return (
+        as_utc(value)
+        .astimezone(get_timezone(timezone_name))
+        .replace(tzinfo=None)
+        .isoformat()
+    )

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "requests>=2.33,<2.34",
     "snowplow-tracker>=1.1,<1.2",
     "SQLAlchemy>=2.0,<2.1",
+    "tzdata>=2026.3,<2027",
     "WTForms>=3.2,<3.3",
 ]
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -685,10 +685,12 @@ typing-extensions==4.15.0 \
     #   minio
     #   snowplow-tracker
     #   sqlalchemy
-tzdata==2025.3 \
-    --hash=sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1 \
-    --hash=sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7
-    # via kombu
+tzdata==2026.3 \
+    --hash=sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415 \
+    --hash=sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931
+    # via
+    #   kombu
+    #   queue-api
 urllib3==2.6.3 \
     --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
     --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4

--- a/api/requirements_dev.txt
+++ b/api/requirements_dev.txt
@@ -685,10 +685,12 @@ typing-extensions==4.15.0 \
     #   minio
     #   snowplow-tracker
     #   sqlalchemy
-tzdata==2025.3 \
-    --hash=sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1 \
-    --hash=sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7
-    # via kombu
+tzdata==2026.3 \
+    --hash=sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415 \
+    --hash=sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931
+    # via
+    #   kombu
+    #   queue-api
 urllib3==2.6.3 \
     --hash=sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed \
     --hash=sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1072,6 +1072,7 @@ dependencies = [
     { name = "requests" },
     { name = "snowplow-tracker" },
     { name = "sqlalchemy" },
+    { name = "tzdata" },
     { name = "wtforms" },
 ]
 
@@ -1118,6 +1119,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.33,<2.34" },
     { name = "snowplow-tracker", specifier = ">=1.1,<1.2" },
     { name = "sqlalchemy", specifier = ">=2.0,<2.1" },
+    { name = "tzdata", specifier = ">=2026.3,<2027" },
     { name = "wtforms", specifier = ">=3.2,<3.3" },
 ]
 
@@ -1321,11 +1323,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2025.3"
+version = "2026.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]

--- a/appointment-frontend/src/components/appointment/AppointmentSummary.vue
+++ b/appointment-frontend/src/components/appointment/AppointmentSummary.vue
@@ -275,7 +275,7 @@ export default class AppointmentSummary extends Mixins(StepperMixin) {
     if (!date) {
       return ''
     }
-    return CommonUtils.getUTCToTimeZoneTime(date, this.currentOfficeTimezone, formatStr)
+    return CommonUtils.getFormattedDate(date, formatStr)
   }
 
   private async fetchUserAppointments () {

--- a/appointment-frontend/src/components/appointment/DateSelection.vue
+++ b/appointment-frontend/src/components/appointment/DateSelection.vue
@@ -73,7 +73,6 @@ import { Appointment, AppointmentSlot } from '@/models/appointment'
 import CommonUtils from '@/utils/common-util'
 import { Component, Mixins } from 'vue-property-decorator'
 import { mapActions, mapMutations, mapState } from 'vuex'
-import { zonedTimeToUtc } from 'date-fns-tz'
 import { Office } from '@/models/office'
 import { Service } from '../../models/service'
 import StepperMixin from '@/mixins/StepperMixin.vue'
@@ -128,8 +127,8 @@ export default class DateSelection extends Mixins(StepperMixin) {
 
    private get selectedTimeSlot () {
      return (this.currentAppointmentSlot?.startTime && this.currentAppointmentSlot?.endTime)
-       ? `${CommonUtils.getUTCToTimeZoneTime(this.currentAppointmentSlot?.startTime, this.currentOfficeTimezone, 'hh:mm aaa')} -
-        ${CommonUtils.getUTCToTimeZoneTime(this.currentAppointmentSlot?.endTime, this.currentOfficeTimezone, 'hh:mm aaa')}`
+       ? `${CommonUtils.getFormattedDate(this.currentAppointmentSlot?.startTime, 'hh:mm aaa')} -
+        ${CommonUtils.getFormattedDate(this.currentAppointmentSlot?.endTime, 'hh:mm aaa')}`
        : ''
    }
 
@@ -190,23 +189,19 @@ export default class DateSelection extends Mixins(StepperMixin) {
    }
 
    async selectTimeSlot (slot: AppointmentSlot) {
-     // Note - For cross browser, we must use specific date string format below
-     // Chrome/FF pass with "2020-05-08 09:00" but Safari fails.
-     // Safari needs format from spec, "2020-05-08T09:00-07:00"
-     // (safari also needs timezone offset)
-     let st = zonedTimeToUtc(new Date(`${this.selectedDate} ${slot.startTime}`.replace(/-/g, '/')), this.currentOfficeTimezone).toISOString()
-     let et = zonedTimeToUtc(new Date(`${this.selectedDate} ${slot.endTime}`.replace(/-/g, '/')), this.currentOfficeTimezone).toISOString()
-     st = st.replace('.000Z', '+00').replace('T', ' ')
-     et = et.replace('.000Z', '+00').replace('T', ' ')
      const selectedSlot: AppointmentSlot = {
-       startTime: st,
-       endTime: et
+       startTime: `${this.selectedDate}T${slot.startTime}:00`,
+       endTime: `${this.selectedDate}T${slot.endTime}:00`
      }
      this.setCurrentAppointmentSlot(selectedSlot)
      try {
        const resp = await this.createDraftAppointment()
        if (resp) {
          this.setCurrentDraftAppointment(resp)
+         this.setCurrentAppointmentSlot({
+           startTime: resp.localStartTime,
+           endTime: resp.localEndTime
+         })
          window.scrollTo(0, 0)
          this.stepNext()
        }

--- a/appointment-frontend/src/models/appointment.ts
+++ b/appointment-frontend/src/models/appointment.ts
@@ -26,12 +26,14 @@ export interface Appointment {
   comments: string
   contactInformation: string
   endTime: string
+  localEndTime: string
   office: Office
   officeId: number
   recurringUuid: string
   service: Service
   serviceId: number
   startTime: string
+  localStartTime: string
   appointmentDate?: string
   appointmentStartTime?: string
   appointmentEndTime?: string

--- a/appointment-frontend/src/store/modules/appointment.ts
+++ b/appointment-frontend/src/store/modules/appointment.ts
@@ -38,10 +38,9 @@ export default class AppointmentModule extends VuexModule {
       appointmentsList = appointmentsList.map(appointment => {
         appointment.office = officeList.find(office => (office.officeId === appointment.officeId))
         appointment.service = serviceList.find(service => (service.serviceId === appointment.serviceId))
-        const timezone = appointment.office?.timezone?.timezoneName
-        appointment.appointmentDate = CommonUtils.getUTCToTimeZoneTime(appointment.startTime, timezone, 'MMM dd, yyyy')
-        appointment.appointmentStartTime = CommonUtils.getUTCToTimeZoneTime(appointment.startTime, timezone, 'hh:mmaaaa')
-        appointment.appointmentEndTime = CommonUtils.getUTCToTimeZoneTime(appointment.endTime, timezone, 'hh:mmaaaa')
+        appointment.appointmentDate = CommonUtils.getFormattedDate(appointment.localStartTime, 'MMM dd, yyyy')
+        appointment.appointmentStartTime = CommonUtils.getFormattedDate(appointment.localStartTime, 'hh:mmaaaa')
+        appointment.appointmentEndTime = CommonUtils.getFormattedDate(appointment.localEndTime, 'hh:mmaaaa')
         return appointment
       })
     }

--- a/appointment-frontend/src/store/modules/office.ts
+++ b/appointment-frontend/src/store/modules/office.ts
@@ -198,8 +198,8 @@ export default class OfficeModule extends VuexModule {
   @Action({ rawError: true })
   public setAppointmentValues (appointment: Appointment): void {
     const apppointmentSlot: AppointmentSlot = {
-      startTime: appointment?.startTime,
-      endTime: appointment?.endTime
+      startTime: appointment?.localStartTime,
+      endTime: appointment?.localEndTime
     }
     this.context.commit('setCurrentOffice', appointment?.office)
     this.context.commit('setCurrentService', appointment?.service)

--- a/frontend/jest.timezone.config.js
+++ b/frontend/jest.timezone.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/tests/unit/office-time.spec.ts'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { tsconfig: { esModuleInterop: true } }]
+  }
+}

--- a/frontend/src/components/Agenda/Agenda.vue
+++ b/frontend/src/components/Agenda/Agenda.vue
@@ -214,7 +214,7 @@ export default class Agenda extends Vue {
   private duration (data: any) {
     const { exam } = data
     const start = moment(exam.booking.local_start_time).clone()
-    const end = moment(exam.booking.end_time).clone()
+    const end = moment(exam.booking.local_end_time).clone()
     return `${end.diff(start, 'hours')} hrs`
   }
 

--- a/frontend/src/components/Agenda/Agenda.vue
+++ b/frontend/src/components/Agenda/Agenda.vue
@@ -29,7 +29,7 @@
               >
                 <template
                   #cell(start)="row"
-                >{{ formatDetail(row.item.exam.booking.start_time) }}</template>
+                >{{ formatDetail(row.item.exam.booking.local_start_time) }}</template>
 
                 <template #cell(length)="row">{{ duration(row.item) }}</template>
 
@@ -213,7 +213,7 @@ export default class Agenda extends Vue {
 
   private duration (data: any) {
     const { exam } = data
-    const start = moment(exam.booking.start_time).clone()
+    const start = moment(exam.booking.local_start_time).clone()
     const end = moment(exam.booking.end_time).clone()
     return `${end.diff(start, 'hours')} hrs`
   }

--- a/frontend/src/components/Appointments/appointments.vue
+++ b/frontend/src/components/Appointments/appointments.vue
@@ -351,7 +351,7 @@ export default class Appointments extends Vue {
     }
     this.is_stat = false
     this.getAppointments().then((each) => {
-      const bb = each.find(element => ((moment(event.date).format('YYYY-MM-DD') === moment(element.start_time).format('YYYY-MM-DD')) && (element.stat_flag)));
+      const bb = each.find(element => ((moment(event.date).format('YYYY-MM-DD') === moment(element.local_start_time).format('YYYY-MM-DD')) && (element.stat_flag)));
       if (bb) {
         this.is_stat = true
       }

--- a/frontend/src/components/Appointments/appointments.vue
+++ b/frontend/src/components/Appointments/appointments.vue
@@ -405,13 +405,13 @@ export default class Appointments extends Vue {
 
   setTempEvent (event) {
     this.removeTempEvent()
-    const start = moment(moment.tz(event.start.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name).format()).clone()
+    const start = moment(event.start)
 
     // for draft
     const data: any = {
-      start_time: moment.utc(start).format(),
+      start_time: start.format('YYYY-MM-DD[T]HH:mm:ss'),
       // setting end time aftger 15 min of start to fix over appoinment time      
-      end_time: moment(start).clone().add(15, 'minutes')
+      end_time: moment(start).clone().add(15, 'minutes').format('YYYY-MM-DD[T]HH:mm:ss')
     }
 
     this.postDraftAppointment(data).then((resp) => {

--- a/frontend/src/components/Appointments/appointments.vue
+++ b/frontend/src/components/Appointments/appointments.vue
@@ -96,6 +96,7 @@
 </template>
 
 <script lang="ts">
+import { officeNow, isPastOfficeTime } from '@/utils/office-time'
 /* eslint-disable */
 // /* eslint-disable sort-imports */
 import { Component, Vue } from 'vue-property-decorator'
@@ -172,8 +173,8 @@ export default class Appointments extends Vue {
   mode: any = 'stack'
   weekday: any = [1, 2, 3, 4, 5]
 
-  value: any = ''
-  currentDay: any = moment().format('YYYY-MM-DD')// new Date()
+  value: any = officeNow(this.$store.state.user.office).format('YYYY-MM-DD')
+  get currentDay () { return officeNow(this.$store.state.user.office).format('YYYY-MM-DD') }
 
   is_stat: boolean = false
   _keyListenerNewApp: any = null
@@ -346,7 +347,7 @@ export default class Appointments extends Vue {
 
   selectEvent (event) {
     const eventDate = moment(event.date + " " + event.time);
-    if (eventDate < moment(moment.now())) {
+    if (isPastOfficeTime(eventDate, this.$store.state.user.office)) {
       return
     }
     this.is_stat = false
@@ -387,7 +388,7 @@ export default class Appointments extends Vue {
   }
 
   today () {
-    this.value = ''
+    this.value = officeNow(this.$store.state.user.office).format('YYYY-MM-DD')
     this.calendarSetup()
   }
 

--- a/frontend/src/components/Appointments/appt-booking-modal/appt-blackout-modal.vue
+++ b/frontend/src/components/Appointments/appt-booking-modal/appt-blackout-modal.vue
@@ -961,8 +961,8 @@ export default class AppointmentBlackoutModal extends Vue {
     const date = moment(this.blackout_date).clone().format('YYYY-MM-DD')
     const start = moment(start_time).clone().format('HH:mm:ss')
     const end = moment(end_time).clone().format('HH:mm:ss')
-    const start_date = moment.tz(date + ' ' + start, this.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ')
-    const end_date = moment.tz(date + ' ' + end, this.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ')
+    const start_date = `${date}T${start}`
+    const end_date = `${date}T${end}`
     const uuidv4 = require('uuid').v4
     const recurring_uuid = uuidv4()
     let axiosArray: any = []
@@ -975,8 +975,8 @@ export default class AppointmentBlackoutModal extends Vue {
         const endDateR = moment(item.end).clone().format('YYYY-MM-DD')
         const endTimeR = moment(item.end).clone().format('HH:mm:ss')
         const e: any = {
-          start_time: moment.tz(startDateR + ' ' + startTimeR, this.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ'),
-          end_time: moment.tz(endDateR + ' ' + endTimeR, this.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ'),
+          start_time: `${startDateR}T${startTimeR}`,
+          end_time: `${endDateR}T${endTimeR}`,
           citizen_name: this.user_name,
           contact_information: this.user_contact_info,
           blackout_flag: 'Y',
@@ -1109,21 +1109,17 @@ export default class AppointmentBlackoutModal extends Vue {
       this.show_next = false
       return false
     }
-    const start_year = parseInt(moment(this.recurring_start_date).utc().clone().format('YYYY'))
-    const start_month = parseInt(moment(this.recurring_start_date).utc().clone().format('MM'))
-    const start_day = parseInt(moment(this.recurring_start_date).utc().clone().format('DD'))
-    const start_hour = parseInt(moment(recurring_start_time).utc().clone().format('HH'))
+    const start_year = parseInt(moment(this.recurring_start_date).format('YYYY'))
+    const start_month = parseInt(moment(this.recurring_start_date).format('MM'))
+    const start_day = parseInt(moment(this.recurring_start_date).format('DD'))
     const local_start_hour = parseInt(moment(recurring_start_time).clone().format('HH'))
-    const start_minute = parseInt(moment(recurring_start_time).utc().clone().format('mm'))
-    const end_year = parseInt(moment(this.recurring_end_date).utc().clone().format('YYYY'))
-    const end_month = parseInt(moment(this.recurring_end_date).utc().clone().format('MM'))
-    const end_day = parseInt(moment(this.recurring_end_date).utc().clone().format('DD'))
-    const end_hour = parseInt(moment(recurring_end_time).utc().clone().format('HH'))
-    const end_minute = parseInt(moment(recurring_end_time).utc().clone().format('mm'))
+    const start_minute = parseInt(moment(recurring_start_time).format('mm'))
+    const end_year = parseInt(moment(this.recurring_end_date).format('YYYY'))
+    const end_month = parseInt(moment(this.recurring_end_date).format('MM'))
+    const end_day = parseInt(moment(this.recurring_end_date).format('DD'))
     const duration = moment.duration(moment(recurring_end_time).diff(moment(recurring_start_time)))
     const duration_minutes = duration.asMinutes()
     let input_frequency: any = null
-    let end_adj_day: any = null
     const local_dates_array: any = []
 
     switch (this.selected_frequency[0]) {
@@ -1144,32 +1140,23 @@ export default class AppointmentBlackoutModal extends Vue {
     if (!isNaN(start_year) || !isNaN(end_year)) {
       // IF RRule Breaks, this is where it will happen
       // INC0048019 - fix UTC error by creating new end day and if end_hour is 4pm PACIFIC (16:00) or later then add 1 day to end of series   ozamani 12/17/2020
-      if (start_hour > 15 && end_hour < 8) {
-        end_adj_day = end_day + 1
-      } else {
-        end_adj_day = end_day
-      }
-      const date_start = new Date(Date.UTC(start_year, start_month - 1, start_day, start_hour, start_minute))
-      const until = new Date(Date.UTC(end_year, end_month - 1, end_adj_day, end_hour, end_minute))
+      const date_start = new Date(Date.UTC(start_year, start_month - 1, start_day))
+      const until = new Date(Date.UTC(end_year, end_month - 1, end_day))
 
       const rule = new RRule({
         freq: input_frequency,
         count: this.selected_count,
         byweekday: this.selected_weekdays,
         dtstart: date_start,
-        until: until,
-        tzid: Intl.DateTimeFormat().resolvedOptions().timeZone
+        until: until
       })
       const array = rule.all()
       this.rrule_text = rule.toText()
       array.forEach(date => {
          // INC0048019 - fix UTC error by creating new date field and if local time is 4pm PACIFIC (16:00) or later then add 1 day to series   ozamani 12/17/2020
-        const adj_date = moment(date)
-         if (local_start_hour >= 16 && start_hour == 0) {
-          adj_date.add(1, 'day')
-        }
-        const formatted_start_date = moment(adj_date).clone().set({ hour: local_start_hour }).format('YYYY-MM-DD HH:mm:ssZ')
-        const formatted_end_date = moment(adj_date).clone().set({ hour: local_start_hour }).add(duration_minutes, 'minutes').format('YYYY-MM-DD HH:mm:ssZ')
+        const local_date = moment.utc(date).set({ hour: local_start_hour, minute: start_minute })
+        const formatted_start_date = local_date.format('YYYY-MM-DD[T]HH:mm:ss')
+        const formatted_end_date = local_date.clone().add(duration_minutes, 'minutes').format('YYYY-MM-DD[T]HH:mm:ss')
         local_dates_array.push({ start: formatted_start_date, end: formatted_end_date })
       })
     }
@@ -1444,8 +1431,8 @@ export default class AppointmentBlackoutModal extends Vue {
             if (self.only_this_office[0]){
               //for this office -appointment
               const e: any = {
-                  start_time: moment.tz(date+' '+start, self.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ'),
-                  end_time: moment.tz(date+' '+end, self.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ'),
+                  start_time: `${date}T${start}`,
+                  end_time: `${date}T${end}`,
                   citizen_name: stat_user_name+'_'+self.$store.state.user.office.office_name,
                   contact_information: user_contact_info,
                   stat_flag: true,
@@ -1464,8 +1451,8 @@ export default class AppointmentBlackoutModal extends Vue {
                   if (room.id != '_offsite') {
                     blackout_booking.room_id = room.id
                   }
-                  blackout_booking.start_time = moment.tz(date+' '+start, self.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ')
-                  blackout_booking.end_time = moment.tz(date+' '+end, self.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ')
+                  blackout_booking.start_time = `${date}T${start}`
+                  blackout_booking.end_time = `${date}T${end}`
                   blackout_booking.booking_name = stat_user_name+'_'+self.$store.state.user.office.office_name
                   blackout_booking.booking_contact_information = user_contact_info
                   blackout_booking.stat_flag = true
@@ -1482,8 +1469,8 @@ export default class AppointmentBlackoutModal extends Vue {
               // stat for appointments
               await all_offices.forEach(async function(office) {
                   const e: any = {
-                      start_time: moment.tz(date+' '+start, office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ'),
-                      end_time: moment.tz(date+' '+end, office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ'),
+                      start_time: `${date}T${start}`,
+                      end_time: `${date}T${end}`,
                       citizen_name: stat_user_name+'_'+office.office_name,
                       contact_information: user_contact_info,
                       stat_flag: true,
@@ -1500,8 +1487,8 @@ export default class AppointmentBlackoutModal extends Vue {
                     if (room.id != '_offsite') {
                       blackout_booking.room_id = room.id
                     }
-                    blackout_booking.start_time = moment.tz(date+' '+start, office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ')
-                    blackout_booking.end_time = moment.tz(date+' '+end, office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ')
+                    blackout_booking.start_time = `${date}T${start}`
+                    blackout_booking.end_time = `${date}T${end}`
                     blackout_booking.booking_name = stat_user_name+'_'+office.office_name
                     blackout_booking.booking_contact_information = user_contact_info
                     blackout_booking.stat_flag = true

--- a/frontend/src/components/Appointments/appt-booking-modal/appt-blackout-modal.vue
+++ b/frontend/src/components/Appointments/appt-booking-modal/appt-blackout-modal.vue
@@ -869,17 +869,19 @@ export default class AppointmentBlackoutModal extends Vue {
   }
 
   private async countApptWarning (e) {
+    const blackoutStart = moment(e.start_time)
+    const blackoutEnd = moment(e.end_time)
     this.filtered_appt = this.myappointments.filter(appt => appt.blackout_flag === 'N' && (!appt.stat_flag) &&
-                                                    moment(appt.start_time).format('YYYY-MM-DD HH:mm:ssZ') >= e.start_time &&
-                                                    moment(appt.end_time).format('YYYY-MM-DD HH:mm:ssZ') <= e.end_time)
+                                                    moment(appt.local_start_time).isSameOrAfter(blackoutStart) &&
+                                                    moment(appt.local_end_time).isSameOrBefore(blackoutEnd))
     
     this.filtered_appt_start = this.myappointments.filter(appt => appt.blackout_flag === 'N' && (!appt.stat_flag) &&
-                                                          moment(appt.start_time).format('YYYY-MM-DD HH:mm:ssZ') < e.start_time &&
-                                                          moment(appt.end_time).format('YYYY-MM-DD HH:mm:ssZ') > e.start_time)
+                                                          moment(appt.local_start_time).isBefore(blackoutStart) &&
+                                                          moment(appt.local_end_time).isAfter(blackoutStart))
     
     this.filtered_appt_end = this.myappointments.filter(appt => appt.blackout_flag === 'N' && (!appt.stat_flag) &&
-                                                        moment(appt.start_time).format('YYYY-MM-DD HH:mm:ssZ') < e.end_time &&
-                                                        moment(appt.end_time).format('YYYY-MM-DD HH:mm:ssZ') > e.end_time)
+                                                        moment(appt.local_start_time).isBefore(blackoutEnd) &&
+                                                        moment(appt.local_end_time).isAfter(blackoutEnd))
     this.appt_overlap = this.appt_overlap + this.filtered_appt.length + this.filtered_appt_start.length + this.filtered_appt_end.length
   }
 
@@ -891,9 +893,9 @@ export default class AppointmentBlackoutModal extends Vue {
 
     const date = moment(this.blackout_date).clone().format('YYYY-MM-DD')
     const start = moment(start_time).clone().format('HH:mm:ss')
-    const start_date = moment(date + ' ' + start).format('YYYY-MM-DD HH:mm:ssZ')
+    const start_date = `${date}T${start}`
     const end = moment(end_time).clone().format('HH:mm:ss')
-    const end_date = moment(date + ' ' + end).format('YYYY-MM-DD HH:mm:ssZ')
+    const end_date = `${date}T${end}`
     const uuidv4 = require('uuid').v4
     const recurring_uuid = uuidv4()
     if (this.rrule_array.length > 0) {

--- a/frontend/src/components/Appointments/appt-booking-modal/appt-booking-modal.vue
+++ b/frontend/src/components/Appointments/appt-booking-modal/appt-booking-modal.vue
@@ -911,13 +911,13 @@ export default class ApptBookingModal extends Vue {
       if (!moment.isMoment(start_time)) {
         this.start = moment(start_time)
       }
-      const start = moment(moment.tz(this.start.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name).format()).clone()
-      const end = moment(moment.tz(this.end.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name).format()).clone()
+      const start = moment(this.start)
+      const end = moment(this.end)
       
       this.start = startDateObj
       const e: any = {
-        start_time: moment.utc(start).format(),
-        end_time: moment.utc(end).format(),
+        start_time: start.format('YYYY-MM-DD[T]HH:mm:ss'),
+        end_time: end.format('YYYY-MM-DD[T]HH:mm:ss'),
         service_id,
         citizen_name: this.citizen_name,
         contact_information: this.contact_information

--- a/frontend/src/components/Appointments/appt-booking-modal/appt-booking-modal.vue
+++ b/frontend/src/components/Appointments/appt-booking-modal/appt-booking-modal.vue
@@ -354,6 +354,7 @@
 </template>
 
 <script lang="ts">
+import { isPastOfficeTime } from '@/utils/office-time'
 /* eslint-disable */
 import { Action, namespace } from 'vuex-class'
 import { Component, Prop, Vue } from 'vue-property-decorator'
@@ -800,7 +801,7 @@ export default class ApptBookingModal extends Vue {
         this.selectLength = this.clickedAppt.end.diff(this.clickedAppt.start, 'minutes')
       }
       this.allow_reschedule = true
-      if (this.clickedAppt.start < moment.now()) {
+      if (isPastOfficeTime(this.clickedAppt.start, this.$store.state.user.office)) {
           this.allow_reschedule = false
       }
       this.citizen_name = this.clickedAppt.title

--- a/frontend/src/components/Booking/booking-blackout-modal.vue
+++ b/frontend/src/components/Booking/booking-blackout-modal.vue
@@ -978,8 +978,8 @@ export default class BookingBlackoutModal extends Vue {
     const date = moment(this.blackout_date).clone().format('YYYY-MM-DD')
     const start = moment(start_time).clone().format('HH:mm:ss')
     const end = moment(end_time).clone().format('HH:mm:ss')
-    const start_date_office = moment.tz(date + ' ' + start, this.$store.state.user.office.timezone.timezone_name).format()
-    const end_date_office = moment.tz(date + ' ' + end, this.$store.state.user.office.timezone.timezone_name).format()
+    const start_date_office = `${date}T${start}`
+    const end_date_office = `${date}T${end}`
     const uuidv4 = require('uuid').v4
     let axiosArray: any = []
     const recurring_uuid = uuidv4()
@@ -1041,8 +1041,8 @@ export default class BookingBlackoutModal extends Vue {
             rrule_ind += 1
             let st = moment(ruleDate.start).clone()
             let ed = moment(ruleDate.end).clone()
-            const startOffice = moment.tz(st.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
-            const endOffice = moment.tz(ed.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
+            const startOffice = st.format('YYYY-MM-DD[T]HH:mm:ss')
+            const endOffice = ed.format('YYYY-MM-DD[T]HH:mm:ss')
             const booking: any = {}
             booking.start_time = startOffice
             booking.end_time = endOffice
@@ -1059,8 +1059,8 @@ export default class BookingBlackoutModal extends Vue {
             const booking: any = {}
             let st = moment(ruleDate.start).clone()
             let ed = moment(ruleDate.end).clone()
-            const startOffice = moment.tz(st.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
-            const endOffice = moment.tz(ed.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
+            const startOffice = st.format('YYYY-MM-DD[T]HH:mm:ss')
+            const endOffice = ed.format('YYYY-MM-DD[T]HH:mm:ss')
             booking.start_time = startOffice
             booking.end_time = endOffice
             booking.booking_name = self.blackout_name
@@ -1079,8 +1079,8 @@ export default class BookingBlackoutModal extends Vue {
             const booking: any = {}
             let st = moment(ruleDate.start).clone()
             let ed = moment(ruleDate.end).clone()
-            const startOffice = moment.tz(st.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
-            const endOffice = moment.tz(ed.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
+            const startOffice = st.format('YYYY-MM-DD[T]HH:mm:ss')
+            const endOffice = ed.format('YYYY-MM-DD[T]HH:mm:ss')
             booking.room_id = room
             booking.start_time = startOffice
             booking.end_time = endOffice
@@ -1192,7 +1192,7 @@ export default class BookingBlackoutModal extends Vue {
     const start_month = parseInt(moment(this.recurring_booking_start_date).clone().format('MM'))
     const start_day = parseInt(moment(this.recurring_booking_start_date).clone().format('DD'))
     const local_start_hour = parseInt(moment(recurring_booking_start_time).clone().format('HH'))
-    const start_minute = parseInt(moment(recurring_booking_start_time).utc().clone().format('mm'))
+    const start_minute = parseInt(moment(recurring_booking_start_time).format('mm'))
     const end_year = parseInt(moment(this.recurring_booking_end_date).clone().format('YYYY'))
     const end_month = parseInt(moment(this.recurring_booking_end_date).clone().format('MM'))
     const end_day = parseInt(moment(this.recurring_booking_end_date).clone().format('DD'))
@@ -1234,12 +1234,9 @@ export default class BookingBlackoutModal extends Vue {
       this.booking_rrule_text = rule.toText()
       array.forEach(date => {
         // created date_with_offset to fix pst -> utc 5pm bug
-        const date_with_offset = moment(date).clone().set({ hour: local_start_hour, minute: start_minute }).add(new Date().getTimezoneOffset(), 'minutes')
-        if (local_start_hour >= 8 && local_start_hour < 15) {
-          date_with_offset.add(1, 'day')
-        }
-        const formatted_start_date = moment(date_with_offset).clone().set({ hour: local_start_hour, minute: start_minute }).format('YYYY-MM-DD HH:mm:ssZ')
-        const formatted_end_date = moment(date_with_offset).clone().set({ hour: local_start_hour, minute: start_minute }).add(duration_minutes, 'minutes').format('YYYY-MM-DD HH:mm:ssZ')
+        const local_date = moment.utc(date).set({ hour: local_start_hour, minute: start_minute })
+        const formatted_start_date = local_date.format('YYYY-MM-DD[T]HH:mm:ss')
+        const formatted_end_date = local_date.clone().add(duration_minutes, 'minutes').format('YYYY-MM-DD[T]HH:mm:ss')
         local_booking_dates_array.push({ start: formatted_start_date, end: formatted_end_date })
       })
     }
@@ -1522,8 +1519,8 @@ export default class BookingBlackoutModal extends Vue {
               // stat for appointments
                if (self.only_bookings.length === 0) {
                   const e: any = {
-                      start_time: moment.tz(date+' '+start, self.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ'),
-                      end_time: moment.tz(date+' '+end, self.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ'),
+                      start_time: `${date}T${start}`,
+                      end_time: `${date}T${end}`,
                       citizen_name: stat_user_name+'_'+self.$store.state.user.office.office_name,
                       contact_information: user_contact_info,
                       stat_flag: true,
@@ -1540,8 +1537,8 @@ export default class BookingBlackoutModal extends Vue {
                 if (room.id != '_offsite') {
                   blackout_booking.room_id = room.id
                 }
-                blackout_booking.start_time = moment.tz(date+' '+start, self.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ')
-                blackout_booking.end_time = moment.tz(date+' '+end, self.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ')
+                blackout_booking.start_time = `${date}T${start}`
+                blackout_booking.end_time = `${date}T${end}`
                 blackout_booking.booking_name = stat_user_name+'_'+self.$store.state.user.office.office_name
                 blackout_booking.booking_contact_information = user_contact_info
                 blackout_booking.stat_flag = true
@@ -1558,8 +1555,8 @@ export default class BookingBlackoutModal extends Vue {
           else if (self.only_this_office.length == 0) {
               all_offices.forEach(async function(office) {
                   const e: any = {
-                      start_time: moment.tz(date+' '+start, office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ'),
-                      end_time: moment.tz(date+' '+end, office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ'),
+                      start_time: `${date}T${start}`,
+                      end_time: `${date}T${end}`,
                       citizen_name: stat_user_name+'_'+office.office_name,
                       contact_information: user_contact_info,
                       stat_flag: true,
@@ -1576,8 +1573,8 @@ export default class BookingBlackoutModal extends Vue {
                     if (room.id != '_offsite') {
                       blackout_booking.room_id = room.id
                     }
-                    blackout_booking.start_time = moment.tz(date+' '+start, office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ')
-                    blackout_booking.end_time = moment.tz(date+' '+end, office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ssZ')
+                    blackout_booking.start_time = `${date}T${start}`
+                    blackout_booking.end_time = `${date}T${end}`
                     blackout_booking.booking_name = stat_user_name+'_'+office.office_name
                     blackout_booking.booking_contact_information = user_contact_info
                     blackout_booking.stat_flag = true

--- a/frontend/src/components/Booking/booking-modal.vue
+++ b/frontend/src/components/Booking/booking-modal.vue
@@ -485,16 +485,16 @@ export default class BookingModal extends Vue {
         }
       }
       // TOCHECK removed new keyword in moment. not needed
-      let end = moment(this.endTime).utc()
-      const start = moment.tz(this.date.start.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name).utc()
+      let end = moment(this.endTime)
+      const start = moment(this.date.start)
       if (this.endTime) {
-        end = moment.tz(this.endTime.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name).utc()
+        end = moment(this.endTime)
       }
 
       const booking: any = {
         room_id: this.date.resource.id,
-        start_time: start.format('YYYY-MM-DD[T]HH:mm:ssZ'),
-        end_time: end.format('YYYY-MM-DD[T]HH:mm:ssZ'),
+        start_time: start.format('YYYY-MM-DD[T]HH:mm:ss'),
+        end_time: end.format('YYYY-MM-DD[T]HH:mm:ss'),
         fees: 'false',
         booking_name: this.exam.exam_name,
         sbc_staff_invigilated: 0,

--- a/frontend/src/components/Booking/calendar.vue
+++ b/frontend/src/components/Booking/calendar.vue
@@ -332,8 +332,7 @@ export default class Calendar extends Vue {
     if (info.weekday === 6 || info.weekday === 0) {
       return false
     }
-    const today =  moment.tz(moment().format(), this.$store.state.user.office.timezone.timezone_name).format('YYYY-MM-DD HH:mm:ss')
-    if (info.start.isBefore(moment(today))) {
+    if (info.start.isBefore(moment())) {
       return false
     }
 

--- a/frontend/src/components/Booking/calendar.vue
+++ b/frontend/src/components/Booking/calendar.vue
@@ -152,6 +152,7 @@
 </template>
 
 <script lang="ts">
+import { officeNow, isPastOfficeTime } from '@/utils/office-time'
 /* eslint-disable */
 import { Action, Getter, Mutation, State } from 'vuex-class'
 import { Component, Vue, Watch } from 'vue-property-decorator'
@@ -258,13 +259,13 @@ export default class Calendar extends Vue {
   categoryDays: number = categoryDefaultDays
   mode: any = 'stack'
   weekday: any = [1, 2, 3, 4, 5]
-  start: any = moment().format('YYYY-MM-DD')
+  start: any = officeNow(this.$store.state.user.office).format('YYYY-MM-DD')
   startTime : string = '08:30'
   intervalCount : string = '17'
 
-  value: any = ''
+  value: any = officeNow(this.$store.state.user.office).format('YYYY-MM-DD')
   eventsList: any = []
-  currentDay: any = moment().format('YYYY-MM-DD')// new Date()
+  get currentDay () { return officeNow(this.$store.state.user.office).format('YYYY-MM-DD') }
 
   categories: any = []
   show_loading: boolean = false
@@ -332,7 +333,7 @@ export default class Calendar extends Vue {
     if (info.weekday === 6 || info.weekday === 0) {
       return false
     }
-    if (info.start.isBefore(moment())) {
+    if (isPastOfficeTime(info.start, this.$store.state.user.office)) {
       return false
     }
 
@@ -664,7 +665,7 @@ export default class Calendar extends Vue {
   }
 
   today () {
-    this.value = ''
+    this.value = officeNow(this.$store.state.user.office).format('YYYY-MM-DD')
     this.type = 'category'
     this.viewRender()
   }

--- a/frontend/src/components/Booking/edit-booking-modal.vue
+++ b/frontend/src/components/Booking/edit-booking-modal.vue
@@ -1145,10 +1145,10 @@ export default class EditBooking extends Vue {
           this.message = 'Selected date/time is is in the past. Press Reschedule and pick a new time.'
           return
         }
-        changes.start_time = this.start.utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+        changes.start_time = this.start.format('YYYY-MM-DD[T]HH:mm:ss')
       }
       if (!(this.end as any).isSame(this.event.end)) {
-        changes.end_time = (this.end as any).utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+        changes.end_time = (this.end as any).format('YYYY-MM-DD[T]HH:mm:ss')
       }
       if (this.newEvent && (this.newEvent.resource.id != this.event.resourceId)) {
         changes.room_id = this.newEvent.resource.id

--- a/frontend/src/components/Booking/edit-booking-modal.vue
+++ b/frontend/src/components/Booking/edit-booking-modal.vue
@@ -633,6 +633,7 @@
 </template>
 
 <script lang="ts">
+import { isPastOfficeTime } from '@/utils/office-time'
 /* eslint-disable */
 import { Action, Getter, Mutation, State, namespace } from 'vuex-class'
 import { Component, Prop, Vue } from 'vue-property-decorator'
@@ -1141,7 +1142,7 @@ export default class EditBooking extends Vue {
             return
           }
         }
-        if (moment().isAfter(this.start)) {
+        if (isPastOfficeTime(this.start, this.event.office || this.$store.state.user.office)) {
           this.message = 'Selected date/time is is in the past. Press Reschedule and pick a new time.'
           return
         }

--- a/frontend/src/components/Booking/other-booking-modal.vue
+++ b/frontend/src/components/Booking/other-booking-modal.vue
@@ -785,12 +785,10 @@ export default class OtherBookingModal extends Vue {
       this.other_rrule_array.forEach(date => {
         let st = moment(date.start).clone()
         let ed = moment(date.end).clone()
-        const startOffice = moment.tz(st.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
-        const endOffice = moment.tz(ed.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
         const booking = {
           room_id: self.resource.id,
-          start_time:startOffice,
-          end_time: endOffice,
+          start_time: st.format('YYYY-MM-DD[T]HH:mm:ss'),
+          end_time: ed.format('YYYY-MM-DD[T]HH:mm:ss'),
           fees: self.recurring_fees,
           booking_name: self.recurring_title,
           booking_contact_information: self.recurring_contact_information,
@@ -817,21 +815,15 @@ export default class OtherBookingModal extends Vue {
       this.message = ''
       this.state = null
       // JSTOTS TOCHECK removed new from moment. no need to use new with moment
-      let start = moment(this.startTime).utc()
-     if (this.startTime) {
-       start = moment.tz(this.startTime.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name).utc()
-     }
+      const start = moment(this.startTime)
 
       // JSTOTS TOCHECK removed new from moment. no need to use new with moment
-      let end = moment(this.endTime).utc()
-      if (this.endTime) {
-        end = moment.tz(this.endTime.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name).utc()
-      }
+      const end = moment(this.endTime)
 
       const booking = {
         room_id: this.resource.id,
-        start_time: start.format('YYYY-MM-DD[T]HH:mm:ssZ'),
-        end_time: end.format('YYYY-MM-DD[T]HH:mm:ssZ'),
+        start_time: start.format('YYYY-MM-DD[T]HH:mm:ss'),
+        end_time: end.format('YYYY-MM-DD[T]HH:mm:ss'),
         fees: this.fees,
         booking_name: this.title,
         booking_contact_information: this.contact_information
@@ -967,22 +959,16 @@ export default class OtherBookingModal extends Vue {
     }
     // Commented out start/end variables are for testing 5pm pst -> utc conversion bug
     // Removed these variables from the date_start and until variable declarations
-    const other_recurring_start_date = moment.tz(moment(this.other_recurring_start_date).format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
-    const start_year = parseInt(moment(other_recurring_start_date).utc().clone().format('YYYY'))
-    const start_month = parseInt(moment(other_recurring_start_date).utc().clone().format('MM'))
-    const start_day = parseInt(moment(other_recurring_start_date).utc().clone().subtract(4, 'hours').format('DD'))
-    const other_recurring_start_time = moment.tz(moment(recurring_start_time_obj).format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
-    const local_start_hour = parseInt(moment(other_recurring_start_time).clone().format('HH'))
-    const local_start_minute = parseInt(moment(other_recurring_start_time).clone().format('mm'))
-    const other_recurring_end_date_obj = moment(this.other_recurring_end_date).clone()
-    const other_recurring_end_date = moment.tz(other_recurring_end_date_obj.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
-    const end_year = parseInt(moment(other_recurring_end_date).utc().clone().format('YYYY'))
-    const end_month = parseInt(moment(other_recurring_end_date).utc().clone().format('MM'))
-    const end_day = parseInt(moment(other_recurring_end_date).utc().clone().format('DD'))
-    const other_recurring_end_time_obj = moment(recurring_end_time_obj).clone()
-    const other_recurring_end_time = moment.tz(other_recurring_end_time_obj.format('YYYY-MM-DD HH:mm:ss'), this.$store.state.user.office.timezone.timezone_name)
-    const local_end_hour = parseInt(moment(other_recurring_end_time).clone().format('HH'))
-    const local_end_minute = parseInt(moment(other_recurring_end_time).clone().format('mm'))
+    const start_year = parseInt(moment(this.other_recurring_start_date).format('YYYY'))
+    const start_month = parseInt(moment(this.other_recurring_start_date).format('MM'))
+    const start_day = parseInt(moment(this.other_recurring_start_date).format('DD'))
+    const local_start_hour = parseInt(moment(recurring_start_time_obj).format('HH'))
+    const local_start_minute = parseInt(moment(recurring_start_time_obj).format('mm'))
+    const end_year = parseInt(moment(this.other_recurring_end_date).format('YYYY'))
+    const end_month = parseInt(moment(this.other_recurring_end_date).format('MM'))
+    const end_day = parseInt(moment(this.other_recurring_end_date).format('DD'))
+    const local_end_hour = parseInt(moment(recurring_end_time_obj).format('HH'))
+    const local_end_minute = parseInt(moment(recurring_end_time_obj).format('mm'))
     let input_frequency: any = null
     const local_other_dates_array: any = []
 
@@ -1003,8 +989,8 @@ export default class OtherBookingModal extends Vue {
 
     if (!isNaN(start_year) || !isNaN(end_year)) {
       // IF RRule Breaks, this is where it will happen
-      const date_start = new Date(start_year+'/'+start_month+'/'+start_day)
-      let until = new Date(end_year+'/'+end_month+'/'+end_day)
+      const date_start = new Date(Date.UTC(start_year, start_month - 1, start_day))
+      const until = new Date(Date.UTC(end_year, end_month - 1, end_day))
       const rule = new RRule({
         freq: input_frequency,
         count: this.other_selected_count,
@@ -1023,11 +1009,11 @@ export default class OtherBookingModal extends Vue {
           if (local_start_hour >= 8 && local_start_hour < 16) {
             date_with_offset.add(1, 'd')
           }
-          const formatted_start_date = moment(date).clone().set({ hour: local_start_hour, minute: local_start_minute }).format('YYYY-MM-DD HH:mm:ssZ')
+          const formatted_start_date = moment.utc(date).set({ hour: local_start_hour, minute: local_start_minute }).format('YYYY-MM-DD[T]HH:mm:ss')
           if (num_days < 0) {
             num_days = 0
           }
-          const formatted_end_date = moment(date).clone().set({ hour: local_end_hour, minute: local_end_minute }).format('YYYY-MM-DD HH:mm:ssZ')
+          const formatted_end_date = moment.utc(date).set({ hour: local_end_hour, minute: local_end_minute }).format('YYYY-MM-DD[T]HH:mm:ss')
           local_other_dates_array.push({ start: formatted_start_date, end: formatted_end_date })
       })
 
@@ -1079,4 +1065,3 @@ export default class OtherBookingModal extends Vue {
   color: red !important;
 }
 </style>
-

--- a/frontend/src/components/Booking/other-booking-modal.vue
+++ b/frontend/src/components/Booking/other-booking-modal.vue
@@ -957,8 +957,6 @@ export default class OtherBookingModal extends Vue {
       this.recurring_form_state = ''
       return false
     }
-    // Commented out start/end variables are for testing 5pm pst -> utc conversion bug
-    // Removed these variables from the date_start and until variable declarations
     const start_year = parseInt(moment(this.other_recurring_start_date).format('YYYY'))
     const start_month = parseInt(moment(this.other_recurring_start_date).format('MM'))
     const start_day = parseInt(moment(this.other_recurring_start_date).format('DD'))
@@ -1001,18 +999,8 @@ export default class OtherBookingModal extends Vue {
 
       const array = rule.all()
       this.other_rrule_text = rule.toText()
-      // JSTOTS added typr for this.startTime
-      const first_event_start_day: any = moment(this.startTime).clone().set({ hour: local_start_hour, minute: local_start_minute }).add(new Date((this.startTime as any)).getTimezoneOffset(), 'minutes')
-      let num_days = Math.floor(moment.duration(first_event_start_day.diff(moment(new Date()))).asDays())
       array.forEach(date => {
-          const date_with_offset = moment(date).clone().set({ hour: local_start_hour, minute: local_start_minute }).add(new Date(date).getTimezoneOffset(), 'minutes')
-          if (local_start_hour >= 8 && local_start_hour < 16) {
-            date_with_offset.add(1, 'd')
-          }
           const formatted_start_date = moment.utc(date).set({ hour: local_start_hour, minute: local_start_minute }).format('YYYY-MM-DD[T]HH:mm:ss')
-          if (num_days < 0) {
-            num_days = 0
-          }
           const formatted_end_date = moment.utc(date).set({ hour: local_end_hour, minute: local_end_minute }).format('YYYY-MM-DD[T]HH:mm:ss')
           local_other_dates_array.push({ start: formatted_start_date, end: formatted_end_date })
       })

--- a/frontend/src/components/agenda-screen/agenda-screen.vue
+++ b/frontend/src/components/agenda-screen/agenda-screen.vue
@@ -268,7 +268,7 @@ export default class AgendaScreen extends Vue {
       service_id: appt.service_id,
       comments: appt.comments,
       start: moment(appt.local_start_time),
-      end: moment(appt.end_time),
+      end: moment(appt.local_end_time),
       appointment_id: appt.appointment_id,
       recurring_uuid: null,
       blackout_flag: 'N',
@@ -279,7 +279,7 @@ export default class AgendaScreen extends Vue {
     this.setAgendaClickedAppt(tempEvent)
     this.clickedTime =  {
       start: moment(appt.local_start_time),
-      end: moment(appt.end_time)
+      end: moment(appt.local_end_time)
     }
     this.setAgendaClickedTime(this.clickedTime);
 

--- a/frontend/src/components/agenda-screen/agenda-screen.vue
+++ b/frontend/src/components/agenda-screen/agenda-screen.vue
@@ -183,7 +183,7 @@ export default class AgendaScreen extends Vue {
       const service_name = service ? service.service_name : 'N/A';
       
       return {
-        start_time: appt.start_time,
+        start_time: appt.local_start_time,
         citizen_name: appt.citizen_name,
         service_name,
         contact_info: appt.contact_information,
@@ -226,16 +226,16 @@ export default class AgendaScreen extends Vue {
       online_flag: appt.online_flag,
       service_id: appt.service_id,
       comments: appt.comments,
-      start: moment(appt.start_time),
-      end: moment(appt.end_time),
+      start: moment(appt.local_start_time),
+      end: moment(appt.local_end_time),
       appointment_id: appt.appointment_id
     }
 
     this.setAgendaClickedAppt(tempEvent)
 
     this.clickedTime =  {
-      start: moment(appt.start_time),
-      end: moment(appt.end_time)
+      start: moment(appt.local_start_time),
+      end: moment(appt.local_end_time)
     }
     this.toggleApptBookingModal(true);
   }
@@ -267,7 +267,7 @@ export default class AgendaScreen extends Vue {
       online_flag: appt.online_flag,
       service_id: appt.service_id,
       comments: appt.comments,
-      start: moment(appt.start_time),
+      start: moment(appt.local_start_time),
       end: moment(appt.end_time),
       appointment_id: appt.appointment_id,
       recurring_uuid: null,
@@ -278,7 +278,7 @@ export default class AgendaScreen extends Vue {
     }
     this.setAgendaClickedAppt(tempEvent)
     this.clickedTime =  {
-      start: moment(appt.start_time),
+      start: moment(appt.local_start_time),
       end: moment(appt.end_time)
     }
     this.setAgendaClickedTime(this.clickedTime);

--- a/frontend/src/components/exams/edit-group-exam-modal.vue
+++ b/frontend/src/components/exams/edit-group-exam-modal.vue
@@ -698,7 +698,6 @@
 import { Action, Getter, Mutation, State } from 'vuex-class'
 import { Component, Prop, Vue } from 'vue-property-decorator'
 import moment from 'moment'
-import zone from 'moment-timezone'
 import DatePicker from 'vue2-datepicker'
 const FileDownload = require('js-file-download')
 
@@ -903,7 +902,7 @@ export default class EditGroupExamBookingModal extends Vue {
 
   checkDate (e) {
     // JSTOTS INFO removed new from moment. no need to use new with moment
-    const date = moment(this.itemCopy.booking.start_time)
+    const date = moment(this.itemCopy.booking.local_start_time)
     // JSTOTS INFO removed new from moment. no need to use new with moment
     this.date = new Date(e)
     this.showMessage = false
@@ -938,7 +937,7 @@ export default class EditGroupExamBookingModal extends Vue {
       }
       return
     }
-    const time = zone.tz(this.itemCopy.booking.start_time, this.editedTimezone).format('HH:mm').toString()
+    const time = moment(this.itemCopy.booking.local_start_time).format('HH:mm').toString()
     // JSTOTS INFO removed new from moment. no need to use new with moment
     const newTime = moment(e).format('HH:mm').toString()
     if (newTime === time) {
@@ -1086,8 +1085,8 @@ export default class EditGroupExamBookingModal extends Vue {
         exam_id,
         invigilator_id: null,
         sbc_staff_invigilated: false,
-        start_time: startNoBook.clone().utc().format('YYYY-MM-DD[T]HH:mm:ssZ'),
-        end_time: end.clone().utc().format('YYYY-MM-DD[T]HH:mm:ssZ'),
+        start_time: startNoBook.format('YYYY-MM-DD[T]HH:mm:ss'),
+        end_time: end.format('YYYY-MM-DD[T]HH:mm:ss'),
         booking_name: this.actionedExam.exam_name
       }
       if (this.invigilator_id) {
@@ -1119,8 +1118,6 @@ export default class EditGroupExamBookingModal extends Vue {
     }
     const edits = this.editedFields
     const putRequests: any = []
-    const local_timezone_name = this.user.office.timezone.timezone_name
-    const edit_timezone_name = this.actionedExam.booking.office.timezone.timezone_name
     const bookingChanges: any = {}
     const invigilator_id_list: any = []
     const current_invigilator_id_list: any = []
@@ -1140,18 +1137,12 @@ export default class EditGroupExamBookingModal extends Vue {
       console.log('    --> Edits include time, date, invigilator, or shadow invigilator')
       const baseDate = moment(this.date).clone().format('YYYY-MM-DD')
       const baseTime = moment(this.time).clone().format('HH:mm:ss')
-      if (local_timezone_name !== edit_timezone_name) {
-        start = zone.tz(`${baseDate}T${baseTime}`, edit_timezone_name)
-      }
-
-      if (local_timezone_name === edit_timezone_name) {
-        start = moment(`${baseDate}T${baseTime}`)
-      }
+      start = moment(`${baseDate}T${baseTime}`)
 
       const end = start.clone().add(parseInt(this.itemCopy.exam_type.number_of_hours), 'h')
 
-      bookingChanges.start_time = start.utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
-      bookingChanges.end_time = end.utc().format('YYYY-MM-DD[T]HH:mm:ssZ')
+      bookingChanges.start_time = start.format('YYYY-MM-DD[T]HH:mm:ss')
+      bookingChanges.end_time = end.format('YYYY-MM-DD[T]HH:mm:ss')
       bookingChanges.sbc_staff_invigilated = false
 
       if (this.shadowInvigilator) {
@@ -1270,13 +1261,10 @@ export default class EditGroupExamBookingModal extends Vue {
       })
     }
     const tempItem = Object.assign({}, this.actionedExam)
-    if (tempItem.booking && tempItem.booking.start_time) {
-      const { start_time } = tempItem.booking
-      const { timezone_name } = this.actionedExam.booking.office.timezone
-      const time = zone.tz(start_time, timezone_name).clone().format('YYYY-MM-DD[T]HH:mm:ss').toString()
-      this.time = new Date(time)
-      const date = zone.tz(start_time, timezone_name).clone().format('YYYY-MM-DD[T]HH:mm:ssZ').toString()
-      this.date = new Date(date)
+    if (tempItem.booking && tempItem.booking.local_start_time) {
+      const { local_start_time } = tempItem.booking
+      this.time = new Date(local_start_time)
+      this.date = new Date(local_start_time)
       if (tempItem.booking.sbc_staff_invigilated) {
         this.invigilator_id = 'sbc'
       } else {

--- a/frontend/src/components/exams/exam-inventory-table.vue
+++ b/frontend/src/components/exams/exam-inventory-table.vue
@@ -358,7 +358,7 @@
         <template #cell(start_time)="row">
           <span v-if="!row.item.booking">-</span>
           <span
-            v-else-if="checkStartDate(row.item.booking.start_time,row.item.exam_returned_date)"
+            v-else-if="checkStartDate(row.item.booking.local_start_time,row.item.exam_returned_date)"
             class="expired"
             >{{ formatDate(row.item.booking.local_start_time) }}</span
           >
@@ -1119,7 +1119,7 @@ export default class ExamInventoryTable extends Vue {
   checkExamIsPast (ex: any): boolean {
     if (this.inventoryFilters.expiryFilter === 'current') {
       if (ex.booking) {
-        if (moment(ex.booking.start_time).isBefore(moment(), 'day')) {
+        if (moment(ex.booking.local_start_time).isBefore(moment(), 'day')) {
           return true
         }
       }
@@ -1194,8 +1194,8 @@ export default class ExamInventoryTable extends Vue {
       return true
     }
     if (ex.booking) {
-      if (moment(ex.booking.start_time).isValid()) {
-        if (moment(ex.booking.start_time).isBefore(moment(), 'day')) {
+      if (moment(ex.booking.local_start_time).isValid()) {
+        if (moment(ex.booking.local_start_time).isBefore(moment(), 'day')) {
           return true
         }
       }
@@ -1242,8 +1242,8 @@ export default class ExamInventoryTable extends Vue {
       }
     }
     if (ex.booking) {
-      if (moment(ex.booking.start_time).isValid()) {
-        if (moment(ex.booking.start_time).isBefore(moment(), 'day')) {
+      if (moment(ex.booking.local_start_time).isValid()) {
+        if (moment(ex.booking.local_start_time).isBefore(moment(), 'day')) {
           return true
         }
       }
@@ -1265,8 +1265,8 @@ export default class ExamInventoryTable extends Vue {
       return true
     }
     if (ex.booking) {
-      if (moment(ex.booking.start_time).isValid()) {
-        if (moment(ex.booking.start_time).isBefore(moment(), 'day')) {
+      if (moment(ex.booking.local_start_time).isValid()) {
+        if (moment(ex.booking.local_start_time).isBefore(moment(), 'day')) {
           return true
         }
       }
@@ -1296,8 +1296,8 @@ export default class ExamInventoryTable extends Vue {
 
   checkExamStart (ex:any, checkInvig:boolean = false): boolean {
     if (ex.booking) {
-      if (moment(ex.booking.start_time).isValid()) {
-        if (moment(ex.booking.start_time).isBefore(moment(), 'day')) {
+      if (moment(ex.booking.local_start_time).isValid()) {
+        if (moment(ex.booking.local_start_time).isBefore(moment(), 'day')) {
           return true
         }
       }
@@ -1320,7 +1320,7 @@ export default class ExamInventoryTable extends Vue {
 
   checkStartDate (date, exam_returned_date) {
     // duplicated code
-    this.checkExpiryDate(date, exam_returned_date)
+    return this.checkExpiryDate(date, exam_returned_date)
   }
 
   filteredExams () {
@@ -1762,8 +1762,8 @@ export default class ExamInventoryTable extends Vue {
         return lifeRing
       }
       if (item.booking) {
-        if (moment(item.booking.start_time).isValid()) {
-          if (moment(item.booking.start_time).isBefore(moment(), 'day')) {
+        if (moment(item.booking.local_start_time).isValid()) {
+          if (moment(item.booking.local_start_time).isBefore(moment(), 'day')) {
             return lifeRing
           }
         }
@@ -1787,8 +1787,8 @@ export default class ExamInventoryTable extends Vue {
         return lifeRing
       }
       if (item.booking) {
-        if (moment(item.booking.start_time).isValid()) {
-          if (moment(item.booking.start_time).isBefore(moment(), 'day')) {
+        if (moment(item.booking.local_start_time).isValid()) {
+          if (moment(item.booking.local_start_time).isBefore(moment(), 'day')) {
             return lifeRing
           }
         }
@@ -1802,8 +1802,8 @@ export default class ExamInventoryTable extends Vue {
       return lifeRing
     }
     if (item.booking) {
-      if (moment(item.booking.start_time).isValid()) {
-        if (moment(item.booking.start_time).isBefore(moment(), 'day')) {
+      if (moment(item.booking.local_start_time).isValid()) {
+        if (moment(item.booking.local_start_time).isBefore(moment(), 'day')) {
           return lifeRing
         }
       }

--- a/frontend/src/components/exams/exam-inventory-table.vue
+++ b/frontend/src/components/exams/exam-inventory-table.vue
@@ -360,9 +360,9 @@
           <span
             v-else-if="checkStartDate(row.item.booking.start_time,row.item.exam_returned_date)"
             class="expired"
-            >{{ formatDate(row.item.booking.start_time) }}</span
+            >{{ formatDate(row.item.booking.local_start_time) }}</span
           >
-          <span v-else>{{ formatDate(row.item.booking.start_time) }}</span>
+          <span v-else>{{ formatDate(row.item.booking.local_start_time) }}</span>
         </template>
 
         <!--  Field 5 - Exam method??? Don't see it.  -->
@@ -758,7 +758,6 @@ import ReturnExamModal from './return-exam-form-modal.vue'
 import SuccessExamAlert from './success-exam-alert.vue'
 import DeleteExamModal from './delete-exam-modal.vue'
 import AddCitizen from '../AddCitizen/add-citizen.vue'
-import zone from 'moment-timezone'
 import UploadPesticideModal from './upload-pesticide-exam.vue'
 
 @Component({
@@ -1446,11 +1445,8 @@ export default class ExamInventoryTable extends Vue {
   }
 
   formatTime (d) {
-    const tz = d.office.timezone.timezone_name
-    const time = zone.tz(d.start_time, tz).format('2017-MM-DD[T]HH:mm:ss').toString()
-
     // JSTOTS TOCHECK removed new from moment. no need to use new with moment
-    return moment(time).format('h:mm a')
+    return moment(d.local_start_time).format('h:mm a')
   }
 
   getSize () {
@@ -1876,7 +1872,7 @@ export default class ExamInventoryTable extends Vue {
 
   updateCalendarBooking (item) {
     // JSTOTS TOCHECK removed new from moment. no need to use new with moment
-    item.gotoDate = moment(item.booking.start_time)
+    item.gotoDate = moment(item.booking.local_start_time)
     item.referrer = 'rescheduling'
     this.setSelectedExam(item)
     const booking = this.calendarEvents.find(event => event.id == item.booking_id)

--- a/frontend/src/components/exams/exam-inventory-table.vue
+++ b/frontend/src/components/exams/exam-inventory-table.vue
@@ -358,7 +358,7 @@
         <template #cell(start_time)="row">
           <span v-if="!row.item.booking">-</span>
           <span
-            v-else-if="checkStartDate(row.item.booking.local_start_time,row.item.exam_returned_date)"
+            v-else-if="checkStartDate(row.item.booking.local_start_time,row.item.exam_returned_date,row.item)"
             class="expired"
             >{{ formatDate(row.item.booking.local_start_time) }}</span
           >
@@ -371,19 +371,19 @@
           <span
             v-if="
               row.item.exam_type.exam_type_name === 'Monthly Session Exam' &&
-              !checkExpiryDate(row.item.expiry_date,row.item.exam_returned_date)
+              !checkExpiryDate(row.item.expiry_date,row.item.exam_returned_date,row.item)
             "
             >–</span
           >
           <span
             v-else-if="
               row.item.exam_type.group_exam_ind &&
-              !checkExpiryDate(row.item.expiry_date,row.item.exam_returned_date)
+              !checkExpiryDate(row.item.expiry_date,row.item.exam_returned_date,row.item)
             "
             >–</span
           >
           <span
-            v-else-if="checkExpiryDate(row.item.expiry_date,row.item.exam_returned_date)"
+            v-else-if="checkExpiryDate(row.item.expiry_date,row.item.exam_returned_date,row.item)"
             class="expired"
             >{{ formatDate(row.item.expiry_date) }}</span
           >
@@ -743,6 +743,7 @@
 </template>
 
 <script lang="ts">
+import { isPastOfficeTime } from '@/utils/office-time'
 
 import { Action, Getter, Mutation, State } from 'vuex-class'
 import { Component, Vue } from 'vue-property-decorator'
@@ -991,7 +992,7 @@ export default class ExamInventoryTable extends Vue {
   }
 
   checkExpiryDateAndAddCalendarBooking (item) {
-    if (moment(item.expiry_date).isValid() && moment(item.expiry_date).isBefore(moment(), 'day')) {
+    if (moment(item.expiry_date).isValid() && isPastOfficeTime(item.expiry_date, this.examOffice(item), 'day')) {
       this.examExpiryDateScheduling = moment(item.expiry_date).format('MMMM DD, YYYY')
       this.expiryNotificationDialog = true
     } else {
@@ -1092,7 +1093,7 @@ export default class ExamInventoryTable extends Vue {
 
   filterByExpiry (ex) {
     if (moment(ex.expiry_date).isValid()) {
-      if (moment(ex.expiry_date).isBefore(moment(), 'day')) {
+      if (isPastOfficeTime(ex.expiry_date, this.examOffice(ex), 'day')) {
         return true
       }
     }
@@ -1119,7 +1120,7 @@ export default class ExamInventoryTable extends Vue {
   checkExamIsPast (ex: any): boolean {
     if (this.inventoryFilters.expiryFilter === 'current') {
       if (ex.booking) {
-        if (moment(ex.booking.local_start_time).isBefore(moment(), 'day')) {
+        if (isPastOfficeTime(ex.booking.local_start_time, this.examOffice(ex), 'day')) {
           return true
         }
       }
@@ -1195,7 +1196,7 @@ export default class ExamInventoryTable extends Vue {
     }
     if (ex.booking) {
       if (moment(ex.booking.local_start_time).isValid()) {
-        if (moment(ex.booking.local_start_time).isBefore(moment(), 'day')) {
+        if (isPastOfficeTime(ex.booking.local_start_time, this.examOffice(ex), 'day')) {
           return true
         }
       }
@@ -1243,7 +1244,7 @@ export default class ExamInventoryTable extends Vue {
     }
     if (ex.booking) {
       if (moment(ex.booking.local_start_time).isValid()) {
-        if (moment(ex.booking.local_start_time).isBefore(moment(), 'day')) {
+        if (isPastOfficeTime(ex.booking.local_start_time, this.examOffice(ex), 'day')) {
           return true
         }
       }
@@ -1266,7 +1267,7 @@ export default class ExamInventoryTable extends Vue {
     }
     if (ex.booking) {
       if (moment(ex.booking.local_start_time).isValid()) {
-        if (moment(ex.booking.local_start_time).isBefore(moment(), 'day')) {
+        if (isPastOfficeTime(ex.booking.local_start_time, this.examOffice(ex), 'day')) {
           return true
         }
       }
@@ -1297,7 +1298,7 @@ export default class ExamInventoryTable extends Vue {
   checkExamStart (ex:any, checkInvig:boolean = false): boolean {
     if (ex.booking) {
       if (moment(ex.booking.local_start_time).isValid()) {
-        if (moment(ex.booking.local_start_time).isBefore(moment(), 'day')) {
+        if (isPastOfficeTime(ex.booking.local_start_time, this.examOffice(ex), 'day')) {
           return true
         }
       }
@@ -1308,19 +1309,23 @@ export default class ExamInventoryTable extends Vue {
     return false
   }
 
-  checkExpiryDate (date, exam_returned_date) {
+  examOffice (exam) {
+    return exam?.booking?.office || exam?.office || this.user.office
+  }
+
+  checkExpiryDate (date, exam_returned_date, exam) {
     if (exam_returned_date != null) {
       return false
     }
-    if (moment(date).isValid() && moment(date).isBefore(moment(), 'day')) {
+    if (moment(date).isValid() && isPastOfficeTime(date, this.examOffice(exam), 'day')) {
       return true
     }
     return false
   }
 
-  checkStartDate (date, exam_returned_date) {
+  checkStartDate (date, exam_returned_date, exam) {
     // duplicated code
-    return this.checkExpiryDate(date, exam_returned_date)
+    return this.checkExpiryDate(date, exam_returned_date, exam)
   }
 
   filteredExams () {
@@ -1334,7 +1339,7 @@ export default class ExamInventoryTable extends Vue {
     let filtered = []
     if (examInventory.length > 0) {
       if (this.showExamInventoryModal) {
-        filtered = examInventory.filter(ex => moment(ex.expiry_date).isSameOrAfter(moment(), 'day'))
+        filtered = examInventory.filter(ex => !!ex.expiry_date && !isPastOfficeTime(ex.expiry_date, this.examOffice(ex), 'day'))
         const moreFilteredConst: any = filtered.filter((ex: any) => !ex.booking)
         const evenMoreFilteredConst = moreFilteredConst.filter(ex => !ex.offsite_location)
         const { office_id } = this.user
@@ -1365,10 +1370,10 @@ export default class ExamInventoryTable extends Vue {
         filtered = exams
         break
       case 'expired':
-        filtered = exams.filter(ex => moment(ex.expiry_date).isBefore(moment(), 'day'))
+        filtered = exams.filter(ex => isPastOfficeTime(ex.expiry_date, this.examOffice(ex), 'day'))
         break
       case 'current':
-        const step1 = exams.filter(ex => moment(ex.expiry_date).isSameOrAfter(moment(), 'day'))
+        const step1 = exams.filter(ex => !!ex.expiry_date && !isPastOfficeTime(ex.expiry_date, this.examOffice(ex), 'day'))
         const step2 = exams.filter(ex => !ex.expiry_date)
         filtered = step1.concat(step2)
         break
@@ -1763,7 +1768,7 @@ export default class ExamInventoryTable extends Vue {
       }
       if (item.booking) {
         if (moment(item.booking.local_start_time).isValid()) {
-          if (moment(item.booking.local_start_time).isBefore(moment(), 'day')) {
+          if (isPastOfficeTime(item.booking.local_start_time, this.examOffice(item), 'day')) {
             return lifeRing
           }
         }
@@ -1788,7 +1793,7 @@ export default class ExamInventoryTable extends Vue {
       }
       if (item.booking) {
         if (moment(item.booking.local_start_time).isValid()) {
-          if (moment(item.booking.local_start_time).isBefore(moment(), 'day')) {
+          if (isPastOfficeTime(item.booking.local_start_time, this.examOffice(item), 'day')) {
             return lifeRing
           }
         }
@@ -1803,7 +1808,7 @@ export default class ExamInventoryTable extends Vue {
     }
     if (item.booking) {
       if (moment(item.booking.local_start_time).isValid()) {
-        if (moment(item.booking.local_start_time).isBefore(moment(), 'day')) {
+        if (isPastOfficeTime(item.booking.local_start_time, this.examOffice(item), 'day')) {
           return lifeRing
         }
       }

--- a/frontend/src/components/exams/upload-pesticide-exam.vue
+++ b/frontend/src/components/exams/upload-pesticide-exam.vue
@@ -46,7 +46,7 @@
                     <u>Exam Type</u>: {{ this.exam.exam_type.exam_type_name }}<br>
                     <u>Event ID</u>: {{ this.exam.event_id }}<br>
                     <u>Examinee</u>: {{ this.exam.examinee_name }}<br>
-                    <u>Scheduled Date</u>: {{ this.exam.booking === null ? 'N/A' : formatDate(this.exam.booking.start_time) }}
+                    <u>Scheduled Date</u>: {{ this.exam.booking === null ? 'N/A' : formatDate(this.exam.booking.local_start_time) }}
                   </div>
                 <div class="q-id-grid-col px-2">
                   <div style="margin-right: 5px;">Upload Status:</div>

--- a/frontend/src/store/actions/actions-model.ts
+++ b/frontend/src/store/actions/actions-model.ts
@@ -293,8 +293,8 @@ export const commonActions: any = {
               booking.invigilator = b.invigilator
               booking.invigilator_id = b.invigilator_id
             }
-            booking.start = new Date(new Date(b.start_time).toLocaleString('en-US', { timeZone: b.office.timezone.timezone_name }))
-            booking.end = new Date(new Date(b.end_time).toLocaleString('en-US', { timeZone: b.office.timezone.timezone_name }))
+            booking.start = new Date(b.local_start_time)
+            booking.end = new Date(b.local_end_time)
             if ( b.stat_flag && b.blackout_notes) {
               booking.name = b.blackout_notes
             } else {
@@ -1990,14 +1990,8 @@ export const commonActions: any = {
     const start = moment(datetime).local()
     const end = start.clone().add(4, 'hours')
     const booking: any = {
-      start_time: start
-        .clone()
-        .utc()
-        .format('YYYY-MM-DD[T]HH:mm:ssZ'),
-      end_time: end
-        .clone()
-        .utc()
-        .format('YYYY-MM-DD[T]HH:mm:ssZ'),
+      start_time: start.format('YYYY-MM-DD[T]HH:mm:ss'),
+      end_time: end.format('YYYY-MM-DD[T]HH:mm:ss'),
       fees: 'false',
       booking_name: responses.exam_name,
       office_id: context.state.user.office_id

--- a/frontend/src/store/actions/actions-model.ts
+++ b/frontend/src/store/actions/actions-model.ts
@@ -293,6 +293,7 @@ export const commonActions: any = {
               booking.invigilator = b.invigilator
               booking.invigilator_id = b.invigilator_id
             }
+            booking.office = b.office
             booking.start = new Date(b.local_start_time)
             booking.end = new Date(b.local_end_time)
             if ( b.stat_flag && b.blackout_notes) {

--- a/frontend/src/store/helpers/makeBookingReqObj.ts
+++ b/frontend/src/store/helpers/makeBookingReqObj.ts
@@ -1,11 +1,8 @@
 /* eslint-disable indent */
 
 import moment from 'moment'
-import tZone from 'moment-timezone'
 
 export const makeBookingReqObj = (context, responses) => {
-    const timezone_name: any = context.state.user.office.timezone
-
     //  NOTE!!!!  The following lines of code are to allow booking an ITA individual exam
     //            when both the ITA liaison flag and Pesticide liaison flags are false.
     //            If both flags are false, then there are no offices, so the .find statement
@@ -19,32 +16,19 @@ export const makeBookingReqObj = (context, responses) => {
             office => office.office_id == responses.office_id
         )
     }
-    const booking_timezone_name: any = booking_office.timezone.timezone_name
     // JSTOTS TOCHECK removed new from moment. no need to use new with moment
     const date = moment(responses.expiry_date).format('YYYY-MM-DD')
     // JSTOTS TOCHECK removed new from moment. no need to use new with moment
     const time = moment(responses.exam_time).format('HH:mm:ss')
     const datetime = date + 'T' + time
-    let start
-    if (booking_timezone_name != timezone_name) {
-        start = tZone.tz(datetime, booking_timezone_name)
-    } else {
-        // JSTOTS TOCHECK removed new from moment. no need to use new with moment
-        start = moment(datetime).local()
-    }
+    const start = moment(datetime)
     const length = context.state.examTypes.find(
         (ex: any) => ex.exam_type_id == responses.exam_type_id
     ).number_of_hours
     const end = start.clone().add(length, 'hours')
     const booking: any = {
-        start_time: start
-            .clone()
-            .utc()
-            .format('YYYY-MM-DD[T]HH:mm:ssZ'),
-        end_time: end
-            .clone()
-            .utc()
-            .format('YYYY-MM-DD[T]HH:mm:ssZ'),
+        start_time: start.format('YYYY-MM-DD[T]HH:mm:ss'),
+        end_time: end.format('YYYY-MM-DD[T]HH:mm:ss'),
         fees: 'false',
         booking_name: responses.exam_name,
         office_id: responses.office_id

--- a/frontend/src/store/modules/appointments-module.ts
+++ b/frontend/src/store/modules/appointments-module.ts
@@ -72,8 +72,8 @@ export default {
       if (state.appointments.length > 0) {
         return state.appointments.map(apt =>
           ({
-            start: new Date(new Date(apt.start_time).toLocaleString('en-US', { timeZone: apt.office.timezone.timezone_name })),
-            end: new Date(new Date(apt.end_time).toLocaleString('en-US', { timeZone: apt.office.timezone.timezone_name })),
+            start: new Date(apt.local_start_time),
+            end: new Date(apt.local_end_time),
             appointment_id: apt.appointment_id,
             service_id: parseInt(apt.service_id),
             citizen_id: apt.citizen_id,

--- a/frontend/src/utils/office-time.ts
+++ b/frontend/src/utils/office-time.ts
@@ -1,0 +1,37 @@
+import Vue from 'vue'
+import moment from 'moment'
+
+// Keep computed Today/status displays fresh in tabs left open overnight.
+const clock = Vue.observable({ tick: 0 })
+if (typeof window !== 'undefined') {
+  window.setInterval(() => { clock.tick += 1 }, 60000)
+}
+
+// UTC-mode Moments here are comparable wall-clock values, not UTC instants.
+// The API supplies the offset periods from its pinned database, including
+// transitions. Never consult the browser's time zone to obtain office "now".
+export function officeNow (office: any, instant = Date.now()) {
+  // Establish a reactive dependency while still reading exact time on each call.
+  // eslint-disable-next-line no-void
+  void clock.tick
+  const periods = office?.timezone?.clock_offsets || []
+  const period = periods.find(p => Date.parse(p.start) <= instant && instant < Date.parse(p.end))
+  return period
+    ? moment.utc(instant).add(period.offset_seconds, 'seconds')
+    : moment.invalid()
+}
+
+export function officeWallTime (value: any) {
+  // Calendar widgets already carry office wall time in browser-local objects.
+  // Preserve their displayed fields instead of interpreting them as instants.
+  if (value == null || value === '') return moment.invalid()
+  return moment.utc(moment.isMoment(value) || value instanceof Date
+    ? moment(value).format('YYYY-MM-DD[T]HH:mm:ss.SSS')
+    : value)
+}
+
+export function isPastOfficeTime (value: any, office: any, unit?: 'day', instant = Date.now()) {
+  const now = officeNow(office, instant)
+  const wallTime = officeWallTime(value)
+  return !now.isValid() || !wallTime.isValid() || wallTime.isBefore(now, unit)
+}

--- a/frontend/tests/unit/office-time.spec.ts
+++ b/frontend/tests/unit/office-time.spec.ts
@@ -1,0 +1,42 @@
+/* eslint-env jest */
+import { isPastOfficeTime, officeNow } from '../../src/utils/office-time'
+import moment from 'moment'
+
+const office = (offset: number) => ({
+  timezone: {
+    clock_offsets: [{
+      start: '2026-03-08T10:00:00Z', end: '2028-01-01T00:00:00Z', offset_seconds: offset
+    }]
+  }
+})
+
+// Execute this suite under different TZ values; calendar objects must retain
+// their displayed wall time regardless of the runtime's UTC offset.
+test('remote browser accepts a future office slot and rejects a past one', () => {
+  const now = Date.parse('2026-09-09T16:00:00Z') // Vancouver 09:00
+  expect(isPastOfficeTime(moment('2026-09-09T10:00:00'), office(-25200), undefined, now)).toBe(false)
+  expect(isPastOfficeTime(new Date('2026-09-09T08:59:00'), office(-25200), undefined, now)).toBe(true)
+})
+
+test('office date differs at the same instant in Cranbrook and Creston', () => {
+  const now = Date.parse('2026-11-03T06:30:00Z')
+  expect(officeNow(office(-25200), now).format('YYYY-MM-DD HH:mm')).toBe('2026-11-02 23:30')
+  expect(officeNow(office(-21600), now).format('YYYY-MM-DD HH:mm')).toBe('2026-11-03 00:30')
+  expect(isPastOfficeTime('2026-11-02T09:00:00', office(-25200), 'day', now)).toBe(false)
+  expect(isPastOfficeTime('2026-11-02T09:00:00', office(-21600), 'day', now)).toBe(true)
+})
+
+test('cached periods select the new offset at the exact transition', () => {
+  const vancouver = office(-25200)
+  vancouver.timezone.clock_offsets.unshift({
+    start: '2026-01-01T00:00:00Z',
+    end: '2026-03-08T10:00:00Z',
+    offset_seconds: -28800
+  })
+  expect(officeNow(vancouver, Date.parse('2026-03-08T09:59:59Z')).format('HH:mm:ss')).toBe('01:59:59')
+  expect(officeNow(vancouver, Date.parse('2026-03-08T10:00:00Z')).format('HH:mm:ss')).toBe('03:00:00')
+})
+
+test('missing clock data never falls back to browser time for scheduling', () => {
+  expect(isPastOfficeTime('2026-11-02T09:00:00', {}, undefined, Date.parse('2026-11-02T15:00:00Z'))).toBe(true)
+})


### PR DESCRIPTION
- Move timezone conversions from the client to the API and pin the tzdata package.
- Updated date formatting to use ISO 8601 standard (YYYY-MM-DDTHH:mm:ss) across the application.
- Removed timezone conversions on the client that used `moment-timezone` in favor of local time handling.
- Simplified date manipulations by directly using moment instances without unnecessary cloning.
- Added unit tests for timezone utility functions to ensure correct UTC conversions.
- Added helper to ensure consistent usage of local_start_time and local_end_time properties in appointment and booking data structures.