### PR TITLE
Update exam schema and add related tests

### DIFF
--- a/api/app/schemas/bookings/exam_schema.py
+++ b/api/app/schemas/bookings/exam_schema.py
@@ -58,7 +58,7 @@ class ExamSchema(BaseSchema):
     invigilator_id = fields.Int(allow_none=True)
     session_number = fields.Int(allow_none=True)
     exam_returned_ind = fields.Int()
-    exam_returned_date = fields.Str(allow_none=True)
+    exam_returned_date = fields.DateTime(allow_none=True)
     exam_returned_tracking_number = fields.Str(allow_none=True)
     exam_written_ind = fields.Int()
     upload_received_ind = fields.Int(allow_none=True)

--- a/api/app/tests/contracts/schemas.py
+++ b/api/app/tests/contracts/schemas.py
@@ -513,7 +513,7 @@ EXAM_SCHEMA = object_schema(
         "invigilator_id": nullable({"type": "integer"}),
         "session_number": nullable({"type": "integer"}),
         "exam_returned_ind": nullable({"type": "integer"}),
-        "exam_returned_date": nullable({"type": "string"}),
+        "exam_returned_date": nullable(ISO_DATETIME_SCHEMA),
         "exam_returned_tracking_number": nullable({"type": "string"}),
         "exam_written_ind": {"type": "integer"},
         "upload_received_ind": nullable({"type": "integer"}),

--- a/api/app/tests/flows/test_booking_exam_flows.py
+++ b/api/app/tests/flows/test_booking_exam_flows.py
@@ -215,6 +215,66 @@ def test_exam_update_accepts_iso_offset_exam_received_date(
     )
 
 
+def test_exam_return_update_accepts_frontend_date_only_value(
+    app, internal_ga_client, seeded_data
+):
+    """Assert the return-exam form's date-only value persists as UTC."""
+    booking = _create_booking(internal_ga_client, seeded_data, days_from_now=5)
+    exam = _create_exam(
+        internal_ga_client,
+        seeded_data,
+        booking["booking_id"],
+        event_id="event-return-date",
+    )
+
+    response = internal_ga_client.put(
+        f"/exams/{exam['exam_id']}/",
+        json={
+            "exam_returned_date": "2026-09-04",
+            "exam_returned_tracking_number": "TRACK-123",
+            "exam_written_ind": 1,
+        },
+    )
+    body = json_of(response)
+
+    assert_json_response(response, 201)
+    assert body["exam"]["exam_returned_date"] == "2026-09-04T00:00:00+00:00"
+    assert body["exam"]["exam_returned_tracking_number"] == "TRACK-123"
+    assert body["exam"]["exam_written_ind"] == 1
+
+    with app.app_context():
+        from app.models.bookings import Exam
+        from qsystem import db
+
+        saved_exam = db.session.get(Exam, exam["exam_id"])
+        assert saved_exam.exam_returned_date == datetime(
+            2026, 9, 4, tzinfo=ZoneInfo("UTC")
+        )
+
+
+def test_exam_return_update_rejects_invalid_date(
+    internal_ga_client, seeded_data
+):
+    """Assert malformed return dates produce a controlled validation response."""
+    booking = _create_booking(internal_ga_client, seeded_data, days_from_now=5)
+    exam = _create_exam(
+        internal_ga_client,
+        seeded_data,
+        booking["booking_id"],
+        event_id="event-invalid-return-date",
+    )
+
+    response = internal_ga_client.put(
+        f"/exams/{exam['exam_id']}/",
+        json={"exam_returned_date": "not-a-date"},
+    )
+
+    assert_json_response(response, 422)
+    assert json_of(response) == {
+        "message": {"exam_returned_date": ["Not a valid datetime."]}
+    }
+
+
 def test_exam_create_invalid_datetime_returns_validation_response(
     internal_ga_client, seeded_data
 ):

--- a/api/app/tests/test_schema_compatibility.py
+++ b/api/app/tests/test_schema_compatibility.py
@@ -4,8 +4,7 @@ import inspect
 import pkgutil
 import sys
 from datetime import datetime, timezone
-
-import pytest
+from types import SimpleNamespace
 
 
 def _schema_classes():
@@ -175,6 +174,26 @@ def test_exam_schema_accepts_iso_exam_received_date_inputs(app, seeded_data):
             "2026-04-17T07:00:00+00:00"
         )
         assert z_exam.exam_received_date.isoformat() == "2026-04-17T07:00:00+00:00"
+
+
+def test_exam_schema_parses_and_serializes_exam_returned_date(app):
+    """Assert return dates are converted to datetimes before persistence."""
+    with app.app_context():
+        from app.schemas.bookings import ExamSchema
+
+        returned_date_field = ExamSchema().fields["exam_returned_date"]
+
+        assert returned_date_field.deserialize("2026-09-04") == datetime(2026, 9, 4)
+        assert returned_date_field.deserialize("2026-09-04T07:00:00Z") == datetime(
+            2026, 9, 4, 7, tzinfo=timezone.utc
+        )
+        assert returned_date_field.deserialize(None) is None
+        assert returned_date_field.serialize(
+            "exam_returned_date",
+            SimpleNamespace(
+                exam_returned_date=datetime(2026, 9, 4, tzinfo=timezone.utc)
+            ),
+        ) == "2026-09-04T00:00:00+00:00"
 
 
 def test_no_schema_explicitly_uses_strict_literal_z_datetime_format(app, seeded_database):


### PR DESCRIPTION
Fix a regression introduced in the updated API. The frontend sends `exam_returned_date` as `YYYY-MM-DD`, but `ExamSchema` loads it as a string while the model’s `UtcDateTime` column requires a Python datetime, causing an exception `'str' object has no attribute 'tzinfo'`.

I was able to reproduce the error locally and was unable to return an exam because of the exception. This patch resolved the error and exams were correctly marked returned. 